### PR TITLE
fix case sensivity for adaptions folder

### DIFF
--- a/adaptions/GenericAdaption.cpp
+++ b/adaptions/GenericAdaption.cpp
@@ -141,7 +141,7 @@ namespace knobkraft {
 	juce::File GenericAdaption::getAdaptionDirectory()
 	{
 		// Should I make this configurable?
-		return File(File::getSpecialLocation(File::userDocumentsDirectory).getFullPathName() + "/KnobKraft-Orm-adaptions");
+		return File(File::getSpecialLocation(File::userDocumentsDirectory).getFullPathName() + "/KnobKraft-orm-adaptions");
 	}
 
 	std::vector<std::shared_ptr<midikraft::SimpleDiscoverableDevice>> GenericAdaption::allAdaptions()


### PR DESCRIPTION
Currently we install adaptions to
```
adaptions/CMakeLists.txt:       set(ADAPTION_DIRECTORY_PROD $ENV{HOME}/KnobKraft-orm-adaptions)
```
but expect them under
```
adaptions/GenericAdaption.cpp:          return File(File::getSpecialLocation(File::userDocumentsDirectory).getFullPathName() + "/KnobKraft-Orm-adaptions");
```
Note the different case in folder naming. This is a problem on Linux where we usually have case sensitive filesystems.