### PR TITLE
Pioneer Toraiz AS-1 bug fixes and features

### DIFF
--- a/adaptions/PioneerToraiz-AS1.py
+++ b/adaptions/PioneerToraiz-AS1.py
@@ -216,7 +216,14 @@ def escapeToSysex(message):
             msBits = 0
         byteIndex += 1
     return result
-    
+
 
 def isDefaultName(patchName):
     return patchName == "Basic Program"
+
+
+def friendlyBankName(bank_number):
+    """Converts bank numbers to bank names as displayed on the Toraiz AS-1."""
+    if bank_number < 5:
+        return "U{}".format(bank_number + 1)
+    return "F{}".format(bank_number - 4)

--- a/adaptions/PioneerToraiz-AS1.py
+++ b/adaptions/PioneerToraiz-AS1.py
@@ -216,3 +216,7 @@ def escapeToSysex(message):
             msBits = 0
         byteIndex += 1
     return result
+    
+
+def isDefaultName(patchName):
+    return patchName == "Basic Program"

--- a/adaptions/PioneerToraiz-AS1.py
+++ b/adaptions/PioneerToraiz-AS1.py
@@ -137,17 +137,17 @@ def renamePatch(message, new_name):
 
     
 def calculateFingerprint(message):
+    # Calculate a hash from the data block only, ignoring the patch's name.
     dataBlockStart = getDataBlockStart(message)
     if dataBlockStart == -1:
         raise Exception(CANNOT_FIND_DATA_BLOCK)
     dataBlock = message[dataBlockStart:-1]
-    data = unescapeSysex(dataBlock)
-    name = nameFromDump(message)
+    data = unescapeSysex(dataBlock)   
     dummyName = " " * 20
     data[107:107+20] = map(ord, dummyName)
-    # Calculate a hash from the data block only, ignoring the patch's name.
     fingerprint = hashlib.md5(bytearray(data)).hexdigest()    
-    print("Patch '{}' has fingerprint {}.".format(name, fingerprint))   
+    # name = nameFromDump(message)
+    # print("Patch '{}' has fingerprint {}.".format(name, fingerprint))   
     return fingerprint
 
 

--- a/adaptions/PioneerToraiz-AS1.py
+++ b/adaptions/PioneerToraiz-AS1.py
@@ -75,9 +75,9 @@ def numberOfPatchesPerBank():
     return 100
 
 
-def getZeroBasedBankNumber(patchNo):
+def getZeroBasedBankNumber(patch_number):
     """Takes a zero-based patch number and returns the corresponding zero-based bank number."""
-    return patchNo // numberOfPatchesPerBank()
+    return patch_number // numberOfPatchesPerBank()
 
 
 def createProgramDumpRequest(channel, patchNo):
@@ -170,8 +170,7 @@ def convertToEditBuffer(channel, message):
         # To turn a single program dump into an edit buffer dump, we need to remove the bank and program number,
         # and switch the command to 0b00000011
         return message[0:9] + [0b00000011] + message[12:]
-    raise Exception(
-        "Data is neither edit buffer nor single program buffer from Toraiz AS-1")
+    raise Exception("Data is neither edit buffer nor single program buffer from Toraiz AS-1")
 
 
 def convertToProgramDump(channel, message, program_number):
@@ -181,8 +180,7 @@ def convertToProgramDump(channel, message, program_number):
         return message[0:9] + [0b00000010] + [bank, program] + message[10:]
     elif isSingleProgramDump(message):
         return message[0:10] + [bank, program] + message[12:]
-    raise Exception(
-        "Neither edit buffer nor program dump - can't be converted")
+    raise Exception("Neither edit buffer nor program dump - can't be converted")
 
 
 def unescapeSysex(sysex):
@@ -194,8 +192,7 @@ def unescapeSysex(sysex):
         dataIndex += 1
         for i in range(7):
             if dataIndex < len(sysex):
-                result.append(sysex[dataIndex] | (
-                    (msbits & (1 << i)) << (7 - i)))
+                result.append(sysex[dataIndex] | ((msbits & (1 << i)) << (7 - i)))
             dataIndex += 1
     return result
 
@@ -223,8 +220,8 @@ def escapeToSysex(message):
     return result
 
 
-def isDefaultName(patchName):
-    return patchName == "Basic Program"
+def isDefaultName(patch_name):
+    return patch_name == "Basic Program"
 
 
 def friendlyBankName(bank_number):
@@ -234,6 +231,6 @@ def friendlyBankName(bank_number):
     return "F{}".format(bank_number - 4)
 
 
-def friendlyProgramName(programNo):
+def friendlyProgramName(program_number):
     """Converts zero-based program numbers within a bank to the format displayed on the Toraiz AS-1."""
-    return "P{}".format(programNo + 1)
+    return "P{}".format(program_number + 1)

--- a/adaptions/PioneerToraiz-AS1.py
+++ b/adaptions/PioneerToraiz-AS1.py
@@ -75,10 +75,15 @@ def numberOfPatchesPerBank():
     return 100
 
 
+def getZeroBasedBankNumber(patchNo):
+    """Takes a zero-based patch number and returns the corresponding zero-based bank number."""
+    return patchNo // numberOfPatchesPerBank()
+
+
 def createProgramDumpRequest(channel, patchNo):
     # Calculate bank and program - the KnobKraft Orm will just think the patches are 0 to 999, but the Toraiz needs a
     # bank number 0-9 and the patch number within that bank
-    bank = patchNo // numberOfPatchesPerBank()
+    bank = getZeroBasedBankNumber(patchNo)
     program = patchNo % numberOfPatchesPerBank()
     # See page 33 of the Toraiz manual
     return [0xf0, 0b00000000, 0b01000000, 0b00000101, 0b00000000, 0b000000000, 0b00000001, 0b00001000, 0b00010000,
@@ -170,7 +175,7 @@ def convertToEditBuffer(channel, message):
 
 
 def convertToProgramDump(channel, message, program_number):
-    bank = program_number // numberOfPatchesPerBank()
+    bank = getZeroBasedBankNumber(program_number)
     program = program_number % numberOfPatchesPerBank()
     if isEditBufferDump(message):
         return message[0:9] + [0b00000010] + [bank, program] + message[10:]
@@ -227,3 +232,8 @@ def friendlyBankName(bank_number):
     if bank_number < 5:
         return "U{}".format(bank_number + 1)
     return "F{}".format(bank_number - 4)
+
+
+def friendlyProgramName(programNo):
+    """Converts zero-based program numbers within a bank to the format displayed on the Toraiz AS-1."""
+    return "P{}".format(programNo + 1)

--- a/adaptions/PioneerToraiz-AS1.py
+++ b/adaptions/PioneerToraiz-AS1.py
@@ -75,7 +75,7 @@ def numberOfPatchesPerBank():
 def createProgramDumpRequest(channel, patchNo):
     # Calculate bank and program - the KnobKraft Orm will just think the patches are 0 to 999, but the Toraiz needs a
     # bank number 0-9 and the patch number within that bank
-    bank = patchNo / numberOfPatchesPerBank()
+    bank = int(patchNo / numberOfPatchesPerBank())
     program = patchNo % numberOfPatchesPerBank()
     # See page 33 of the Toraiz manual
     return [0xf0, 0b00000000, 0b01000000, 0b00000101, 0b00000000, 0b000000000, 0b00000001, 0b00001000, 0b00010000,

--- a/adaptions/PioneerToraiz-AS1.py
+++ b/adaptions/PioneerToraiz-AS1.py
@@ -78,7 +78,7 @@ def numberOfPatchesPerBank():
 def createProgramDumpRequest(channel, patchNo):
     # Calculate bank and program - the KnobKraft Orm will just think the patches are 0 to 999, but the Toraiz needs a
     # bank number 0-9 and the patch number within that bank
-    bank = int(patchNo / numberOfPatchesPerBank())
+    bank = patchNo // numberOfPatchesPerBank()
     program = patchNo % numberOfPatchesPerBank()
     # See page 33 of the Toraiz manual
     return [0xf0, 0b00000000, 0b01000000, 0b00000101, 0b00000000, 0b000000000, 0b00000001, 0b00001000, 0b00010000,

--- a/adaptions/PioneerToraiz-AS1.py
+++ b/adaptions/PioneerToraiz-AS1.py
@@ -140,3 +140,28 @@ def unescapeSysex(sysex):
                 result.append(sysex[dataIndex] | ((msbits & (1 << i)) << (7 - i)))
             dataIndex += 1
     return result
+    
+
+def escapeToSysex(message):
+    result = []
+    msBits = 0
+    byteIndex = 0
+    chunk = []
+    while byteIndex < len(message):
+        indexInChunk = byteIndex % 7
+        if indexInChunk == 0:
+            chunk = []
+        currentByte = message[byteIndex]
+        lsBits = currentByte & 0x7F
+        msBit = currentByte & 0x80        
+        print("Index: {}; index mod 7: {}; lsBits: {}; masked: {}".format(byteIndex, indexInChunk, lsBits, msBit))
+        msBits |= msBit >> (7 - indexInChunk)
+        print("msBits: {}".format(msBits))
+        chunk.append(lsBits)
+        if indexInChunk == 6 or byteIndex == len(message) - 1:
+            chunk.insert(0, msBits)
+            print("Chunk: {}".format(chunk))
+            result += chunk
+            msBits = 0
+        byteIndex += 1
+    return result


### PR DESCRIPTION
The function createProgramDumpRequest contained a division whose float result was not cast to int before being returned in the resulting list. This was causing the following error when doing "Import patches from synth":

"Adaptation[Pioneer Toraiz AS-1]: Error calling createProgramDumpRequest: Unable to cast Python instance to C++ type (compile in debug mode for details)"

Casting the result of the division to an int before adding it to the list fixes this.