### PR TITLE
New model for synth parameters

### DIFF
--- a/The-Orm/CurrentPatchDisplay.cpp
+++ b/The-Orm/CurrentPatchDisplay.cpp
@@ -25,7 +25,7 @@
 
 MetaDataArea::MetaDataArea(std::vector<CategoryButtons::Category> categories, std::function<void(CategoryButtons::Category, TouchButtonFunction f)> categoryUpdateHandler) :
 	categories_(categories, categoryUpdateHandler, false, false)
-	, patchAsText_([this]() { if (forceResize) forceResize();  }, false)
+	, patchAsText_([this]() { if (forceResize) forceResize();  }, true)
 {
 	addAndMakeVisible(categories_);
 	categories_.setButtonSize(LAYOUT_BUTTON_WIDTH, LAYOUT_TOUCHBUTTON_HEIGHT);

--- a/The-Orm/PatchTextBox.cpp
+++ b/The-Orm/PatchTextBox.cpp
@@ -157,42 +157,83 @@ String PatchTextBox::makeTextDocument(std::shared_ptr<midikraft::PatchHolder> pa
 
 	auto realPatch = std::dynamic_pointer_cast<midikraft::Patch>(patch->patch());
 	if (realPatch) {
-		return patchToTextRaw(realPatch, false);
+		return patchToTextRaw(patch->smartSynth(), realPatch, false);
 	}
 	else {
 		return "makeTextDocument not implemented yet";
 	}
 }
 
-std::string PatchTextBox::patchToTextRaw(std::shared_ptr<midikraft::Patch> patch, bool onlyActive)
+std::string PatchTextBox::patchToTextRaw(std::shared_ptr<midikraft::Synth> synth, std::shared_ptr<midikraft::Patch> patch, bool onlyActive)
 {
 	std::string result;
 
-	int numLayers = 1;
-	auto layers = midikraft::Capability::hasCapability<midikraft::LayeredPatchCapability>(patch);
-	if (layers) {
-		numLayers = layers->numberOfLayers();
-	}
+	auto modernParameters = midikraft::Capability::hasCapability<midikraft::SynthParametersCapability>(synth);
+	if (modernParameters) {
+		auto parameters = modernParameters->getParameterDefinitions();
+		auto values = modernParameters->getParameterValues(patch, true);
 
-	auto parameterDetails = midikraft::Capability::hasCapability<midikraft::DetailedParametersCapability>(patch);
-
-	if (parameterDetails) {
-		for (int layer = 0; layer < numLayers; layer++) {
-			if (layers) {
-				if (layer > 0) result += "\n";
-				result = result + fmt::format("Layer: {}\n", layers->layerName(layer));
+		for (size_t i = 0; i < parameters.size(); i++) {
+			String valueLine = parameters[i].name + ": ";
+			if (values[i].value.isInt()) {
+				valueLine += values[i].value.toString();
 			}
-			for (auto param : parameterDetails->allParameterDefinitions()) {
-				if (layers) {
-					auto multiLayerParam = midikraft::Capability::hasCapability<midikraft::SynthMultiLayerParameterCapability>(param);
-					jassert(multiLayerParam);
-					if (multiLayerParam) {
-						multiLayerParam->setSourceLayer(layer);
+			else if (values[i].value.isString()) {
+				valueLine += values[i].value.toString();
+			}
+			else if (values[i].value.isArray()) {
+				valueLine += "[";
+				bool comma = false;
+				for (auto const& item : *values[i].value.getArray()) {
+					if (comma) {
+						valueLine += ", ";
+					}
+					comma = true;
+					if (item.isInt()) {
+						valueLine += item.toString();
+					}
+					else if (item.isString()) {
+						valueLine += item.toString();
+					}
+					else {
+						valueLine += "ERR";
 					}
 				}
-				auto activeCheck = midikraft::Capability::hasCapability<midikraft::SynthParameterActiveDetectionCapability>(param);
-				if (!onlyActive || !activeCheck || !(activeCheck->isActive(patch.get()))) {
-					result = result + fmt::format("{}: {}\n",param->description(), param->valueInPatchToText(*patch));
+			}
+			else {
+				valueLine += "UNKNOWN";
+			}
+			result += valueLine.toStdString() + "\n";
+		}
+	}
+	else {
+		// Old code, which has more complexity in the implementation, thus it is shorter here
+		int numLayers = 1;
+		auto layers = midikraft::Capability::hasCapability<midikraft::LayeredPatchCapability>(patch);
+		if (layers) {
+			numLayers = layers->numberOfLayers();
+		}
+
+		auto parameterDetails = midikraft::Capability::hasCapability<midikraft::DetailedParametersCapability>(patch);
+
+		if (parameterDetails) {
+			for (int layer = 0; layer < numLayers; layer++) {
+				if (layers) {
+					if (layer > 0) result += "\n";
+					result = result + fmt::format("Layer: {}\n", layers->layerName(layer));
+				}
+				for (auto param : parameterDetails->allParameterDefinitions()) {
+					if (layers) {
+						auto multiLayerParam = midikraft::Capability::hasCapability<midikraft::SynthMultiLayerParameterCapability>(param);
+						jassert(multiLayerParam);
+						if (multiLayerParam) {
+							multiLayerParam->setSourceLayer(layer);
+						}
+					}
+					auto activeCheck = midikraft::Capability::hasCapability<midikraft::SynthParameterActiveDetectionCapability>(param);
+					if (!onlyActive || !activeCheck || !(activeCheck->isActive(patch.get()))) {
+						result = result + fmt::format("{}: {}\n", param->description(), param->valueInPatchToText(*patch));
+					}
 				}
 			}
 		}

--- a/The-Orm/PatchTextBox.h
+++ b/The-Orm/PatchTextBox.h
@@ -23,7 +23,7 @@ public:
 
 	String makeHexDocument(std::shared_ptr<midikraft::PatchHolder> patch);
 	static String makeTextDocument(std::shared_ptr<midikraft::PatchHolder> patch);
-	static std::string patchToTextRaw(std::shared_ptr<midikraft::Patch> patch, bool onlyActive);
+	static std::string patchToTextRaw(std::shared_ptr<midikraft::Synth> synth, std::shared_ptr<midikraft::Patch> patch, bool onlyActive);
 
 	float desiredHeight() const;
 

--- a/synths/sequential-rev2/Rev2.cpp
+++ b/synths/sequential-rev2/Rev2.cpp
@@ -673,15 +673,14 @@ namespace midikraft {
 
 	std::vector<ParamVal> Rev2::getParameterValues(std::shared_ptr<DataFile> const patch, bool onlyActive) const {
 		ignoreUnused(onlyActive); // TBD
-		if (!patch) {
+		auto rev2patch = std::dynamic_pointer_cast<Rev2Patch>(patch);
+		if (!rev2patch) {
 			return {};
 		}
-
-		Rev2Patch dummy;
 		std::vector<ParamVal> result;
 		int i = 0;
 		for (int layer = 0; layer < 2; layer++) {
-			for (auto const& param : dummy.allParameterDefinitions()) {
+			for (auto const& param : rev2patch->allParameterDefinitions()) {
 				auto rev2Param = std::dynamic_pointer_cast<Rev2ParamDefinition>(param);
 				rev2Param->setSourceLayer(layer);
 				switch (param->type()) {
@@ -722,7 +721,61 @@ namespace midikraft {
 	}
 
 	std::vector<float> Rev2::createFeatureVector(std::shared_ptr<DataFile> const patch) const {
-		return {};
+		auto rev2patch = std::dynamic_pointer_cast<Rev2Patch>(patch);
+		if (!rev2patch) {
+			return {};
+		}
+		auto definitions = getParameterDefinitions();
+		std::vector<float> result;
+		int i = 0;
+		for (int layer = 0; layer < 2; layer++) {
+			for (auto const& param : rev2patch->allParameterDefinitions()) {
+				auto rev2Param = std::dynamic_pointer_cast<Rev2ParamDefinition>(param);
+				rev2Param->setSourceLayer(layer);
+				switch (param->type()) {
+				case SynthParameterDefinition::ParamType::INT: {
+					auto intParam = std::dynamic_pointer_cast<SynthIntParameterCapability>(param);
+					int value = 0;
+					if (!intParam->valueInPatch(*patch, value)) {
+						spdlog::error("Failed to get integer value for parameter {}", param->name());
+					}
+					juce::Array<var> minMax = *definitions[i].values.getArray();
+					float range = static_cast<float>(minMax[1].operator int() - minMax[0].operator int());
+					result.push_back(static_cast<float>(value + minMax[0].operator int())/static_cast<float>(range));
+					break;
+				}
+				case SynthParameterDefinition::ParamType::INT_ARRAY: {
+					auto intParam = std::dynamic_pointer_cast<SynthVectorParameterCapability>(param);
+					std::vector<int> values;
+					juce::Array<var> minMax = *definitions[i].values.getArray();
+					float range = static_cast<float>(minMax[1].operator int() - minMax[0].operator int());
+					if (!intParam->valueInPatch(*patch, values)) {
+						spdlog::error("Failed to get integer vector values for parameter {}", param->name());
+					}
+					for (auto const& v : values) {
+						result.push_back(static_cast<float>(v + minMax[0].operator int()) / static_cast<float>(range));
+					}
+					break;
+				}
+				case SynthParameterDefinition::ParamType::LOOKUP: {
+					std::string value = param->valueInPatchToText(*patch);
+					for (auto const& option : *definitions[i].values.getArray()) {
+						if (option == value) {
+							result.push_back(1.0f);
+						}
+						else {
+							result.push_back(0.0f);
+						}
+					}
+					break;
+				}
+				case SynthParameterDefinition::ParamType::LOOKUP_ARRAY:
+					spdlog::error("Lookup Arrays are not implemented for the Rev2, but param {} uses it", param->name());
+				}
+				i = i + 1;
+			}
+		}
+		return result;
 	}
 
 

--- a/synths/sequential-rev2/Rev2.h
+++ b/synths/sequential-rev2/Rev2.h
@@ -12,10 +12,11 @@
 #include "LayerCapability.h"
 #include "DataFileLoadCapability.h"
 #include "DataFileSendCapability.h"
+#include "DetailedParametersCapability.h"
 
 namespace midikraft {
 
-	class Rev2 : public DSISynth, public LayerCapability, public DataFileLoadCapability, public DataFileSendCapability
+	class Rev2 : public DSISynth, public LayerCapability, public DataFileLoadCapability, public DataFileSendCapability, public SynthParametersCapability
 	{
 	public:
 		// Data Item Types
@@ -74,6 +75,11 @@ namespace midikraft {
 
 		// DataFileSendCapability
 		std::vector<MidiMessage> dataFileToMessages(std::shared_ptr<DataFile> dataFile, std::shared_ptr<SendTarget> target) const override;
+
+		// SynthParametersCapability, the new version of the detailed parameters better suited for Python bindings
+		virtual std::vector<ParamDef> getParameterDefinitions() const override;
+		virtual std::vector<ParamVal> getParameterValues(std::shared_ptr<DataFile> const patch, bool onlyActive) const override;
+		virtual std::vector<float> createFeatureVector(std::shared_ptr<DataFile> const patch) const override;
 
 		//TODO These should go into the DSISynth class
 		virtual DataFileLoadCapability *loader() override;

--- a/synths/sequential-rev2/Rev2ParamDefinition.cpp
+++ b/synths/sequential-rev2/Rev2ParamDefinition.cpp
@@ -245,5 +245,9 @@ namespace midikraft {
 		return type_;
 	}
 
+	std::string Rev2ParamDefinition::lookup(int value) {
+		return lookupFunction_(value);
+	}
+
 }
 

--- a/synths/sequential-rev2/Rev2ParamDefinition.h
+++ b/synths/sequential-rev2/Rev2ParamDefinition.h
@@ -47,6 +47,10 @@ namespace midikraft {
 		virtual int getTargetLayer() const override;
 		virtual void setSourceLayer(int layerNo) override;
 		virtual int getSourceLayer() const override;
+
+		// Internal use only, for legacy integration
+		std::string lookup(int value);
+
 	private:
 		ParamType type_;
 		int targetLayer_; // The Rev2 has no layers, A (=0) and B (=0). By default, we target 0 but can change this calling setTargetLayer()

--- a/synths/sequential-rev2/Rev2Patch.cpp
+++ b/synths/sequential-rev2/Rev2Patch.cpp
@@ -46,7 +46,7 @@ namespace midikraft {
 	std::function<std::string(int)> noteNumberToName = [](int value) { return MidiNote(value).name(); };
 
 	std::vector<Rev2ParamDefinition> nrpns = {
-		Rev2ParamDefinition(0, 0, 120, "Osc 1 Freq", 0, noteNumberToName),
+		Rev2ParamDefinition(0, 0, 120, "Osc 1 Freq", 0),
 		Rev2ParamDefinition(1, 0, 100, "Osc 1 Freq Fine", 2),
 		Rev2ParamDefinition(2, 0, 4, "Osc 1 Shape Mod", 4, { {0, "Off"}, { 1, "Saw" }, { 2, "Saw+Triangle"}, { 3, "Triangle" }, { 4, "Pulse" } }),
 		Rev2ParamDefinition(3, 0, 127, "Osc 1 Glide", 8),
@@ -183,7 +183,7 @@ namespace midikraft {
 		Rev2ParamDefinition(168, 0, 1, "Unison On/Off", 123),
 		Rev2ParamDefinition(169, 0, 16, "Unison Mode", 124),
 		Rev2ParamDefinition(170, 0, 5, "Key Mode", 122, { { 0, "Low" }, { 1, "Hi" }, { 2, "Last" }, { 3, "LowR" }, { 4, "HiR"}, {5, "LastR"} }),
-		Rev2ParamDefinition(171, 0, 120, "Split Point", 232, noteNumberToName),
+		Rev2ParamDefinition(171, 0, 120, "Split Point", 232),
 		Rev2ParamDefinition(172, 0, 1, "Arp On/Off", 136),
 		Rev2ParamDefinition(173, 0, 4, "Arp Mode", 132, { { 0, "Up" }, { 1, "Down"}, { 2, "Up+Down" }, { 3, "Random" },  { 4, "Assign" } }),
 		Rev2ParamDefinition(174, 0, 2, "Arp Octave", 133),
@@ -206,17 +206,17 @@ namespace midikraft {
 		Rev2ParamDefinition(224, 239, 0, 126, "Seq Track 3", 172), // 126 is Reset
 		Rev2ParamDefinition(240, 255, 0, 126, "Seq Track 4", 188), // 126 is Reset
 		// TODO - really no values ?
-		Rev2ParamDefinition(276, 339, 0, 127, "Poly Seq Note 1", 256, noteNumberToName),
+		Rev2ParamDefinition(276, 339, 0, 127, "Poly Seq Note 1", 256),
 		Rev2ParamDefinition(340, 403, 128, 255, "Poly Seq Vel 1", 320),
-		Rev2ParamDefinition(404, 467, 0, 127, "Poly Seq Note 2", 384, noteNumberToName),
+		Rev2ParamDefinition(404, 467, 0, 127, "Poly Seq Note 2", 384),
 		Rev2ParamDefinition(468, 531, 128, 255, "Poly Seq Vel 2", 448),
-		Rev2ParamDefinition(532, 595, 0, 127, "Poly Seq Note 3", 512, noteNumberToName),
+		Rev2ParamDefinition(532, 595, 0, 127, "Poly Seq Note 3", 512),
 		Rev2ParamDefinition(596, 659, 128, 255, "Poly Seq Vel 3", 576),
-		Rev2ParamDefinition(660, 723, 0, 127, "Poly Seq Note 4", 640, noteNumberToName),
+		Rev2ParamDefinition(660, 723, 0, 127, "Poly Seq Note 4", 640),
 		Rev2ParamDefinition(724, 787, 128, 255, "Poly Seq Vel 4", 704),
-		Rev2ParamDefinition(788, 851, 0, 127, "Poly Seq Note 5", 768, noteNumberToName),
+		Rev2ParamDefinition(788, 851, 0, 127, "Poly Seq Note 5", 768),
 		Rev2ParamDefinition(852, 915, 128, 255, "Poly Seq Vel 5", 832),
-		Rev2ParamDefinition(916, 979, 0, 127, "Poly Seq Note 6", 896, noteNumberToName),
+		Rev2ParamDefinition(916, 979, 0, 127, "Poly Seq Note 6", 896),
 		Rev2ParamDefinition(980, 1043, 128, 255, "Poly Seq Vel 6", 960)
 	};
 


### PR DESCRIPTION
This prepares #199, as the old model was way too complex for the Python code.

This is C++ and for the Rev2 only, but let's see if it works and then we can a GenericAdaptation interface for it.