### PR TITLE
Simplify bank dump request handling: revert nested list support

### DIFF
--- a/adaptations/Korg_microKORG.py
+++ b/adaptations/Korg_microKORG.py
@@ -171,12 +171,13 @@ def convertToEditBuffer(channel, message):
 def createBankDumpRequest(channel, bank):
     # This sequence is based on the analysis of the sound editor's communication.
     # Knobkraft should send these four messages in order with a small delay.
+    # Return a flat list - the C++ code will split MIDI messages automatically.
     handshake = [0xf0, 0x7e, 0x7f, 0x06, 0x01, 0xf7]
     prep_msg1 = [0xf0, 0x42, 0x30 | (channel & 0x0f), 0x00, 0x01, 0x40, 0x0E, 0xf7]
     prep_msg2 = [0xf0, 0x42, 0x30 | (channel & 0x0f), 0x00, 0x01, 0x40, 0x0F, 0xf7]
     # This is the actual "All Program Data Dump Request"
     dump_request = [0xf0, 0x42, 0x30 | (channel & 0x0f), 0x00, 0x01, 0x40, 0x1D, 0x00, 0xf7]
-    return [handshake, prep_msg1, prep_msg2, dump_request]
+    return handshake + prep_msg1 + prep_msg2 + dump_request
 
 
 def isPartOfBankDump(message):


### PR DESCRIPTION
- Addressing Christof's comments to simplify the implementation
- The C++ code already handles flat list and splits MIDI messages automatically
- Revert nested list handling in GenericBankDumpCapability.cpp
- Update Korg_microKORG.py to return flat list instead of nested list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified bank dump request processing with improved internal data handling efficiency
  * Enhanced logging visibility for bank dump operations through increased verbosity levels
  * Optimized MIDI message generation, sequencing, and delivery in the bank dump workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->