### PR TITLE
Additional 100% AI adaptations (Behringer UB-Xa, Casio CZ-101/CZ-1000, Ensoniq Mirage (Soundprocess OS))

### DIFF
--- a/adaptations/Behringer_UB-Xa.py
+++ b/adaptations/Behringer_UB-Xa.py
@@ -1,0 +1,356 @@
+#
+#   Custom KnobKraft Adaptation for Behringer UB-Xa
+#   Session-based FDS parser (multi-device safe)
+#
+
+from typing import List
+from knobkraft import unescapeSysex_deepmind as unescape_sysex
+import hashlib
+
+_MAX_NAME_CHARS = 16
+
+# ---------------------------------------------------------------------------
+# Manufacturer / Product IDs & Undocumented Wrappers
+# ---------------------------------------------------------------------------
+
+behringer_id = [0x00, 0x20, 0x32]
+ubxa_product = [0x00, 0x01, 0x21]
+
+sysex_prefix = [0xF0] + behringer_id + ubxa_product
+sysex_suffix = 0xF7
+
+_PL = len(sysex_prefix)
+
+# Undocumented FDS wrappers discovered via official app trace
+_BIN_PREFIX = [0x7F, 0x42, 0x49, 0x4E, 0x20] # 7F B I N (space)
+_FW_VERSION = [0x00, 0x03, 0x7C]             # v0.3.124
+
+# ---------------------------------------------------------------------------
+# FDS session tracking
+# ---------------------------------------------------------------------------
+
+class _FDSSession:
+    def __init__(self, device_id: int):
+        self.device_id = device_id
+        self.messages = []
+        self.has_header = False
+        self.has_eof = False
+        self.complete = False
+
+_fds_sessions = {}
+
+def _get_session(device_id: int) -> _FDSSession:
+    if device_id not in _fds_sessions:
+        _fds_sessions[device_id] = _FDSSession(device_id)
+    return _fds_sessions[device_id]
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+def name() -> str:
+    return "Behringer UB-Xa"
+
+def setupHelp() -> str:
+    return (
+        "UB-Xa uses FDS SysEx with ACK-per-packet handshake.\n"
+        "This adapter incorporates the undocumented V0.3.124+ BIN wrappers.\n\n"
+        "IMPORTANT: Ensure 'Rx PC' (Receive Program Change) is turned ON in the UB-Xa Global MIDI Settings so auditioning patches works!"
+    )
+
+# ---------------------------------------------------------------------------
+# Timing
+# ---------------------------------------------------------------------------
+
+def messageTimings():
+    return {
+        "generalMessageDelay": 30,
+        "deviceDetectWaitMilliseconds": 5000,
+        "replyTimeoutMs": 8000,
+    }
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _split_sysex(data) -> List[List[int]]:
+    result = []
+    i = 0
+    data = list(data)
+
+    while i < len(data):
+        if data[i] == 0xF0:
+            start = i
+            while i < len(data) and data[i] != 0xF7:
+                i += 1
+            if i < len(data):
+                result.append(data[start:i + 1])
+        i += 1
+
+    return result
+
+def _is_fds(msg, fds_type=None) -> bool:
+    if not hasattr(msg, '__len__') or len(msg) < _PL + 4:
+        return False
+    if list(msg[0:_PL]) != sysex_prefix:
+        return False
+    if msg[_PL + 1] != 0x74 or msg[_PL + 2] != 0x07:
+        return False
+    if fds_type is not None:
+        return msg[_PL + 3] == fds_type
+    return True
+
+def _fds_device_id(msg) -> int:
+    return msg[_PL]
+
+def _fds_packet_num(msg) -> int:
+    return msg[_PL + 4] if len(msg) > _PL + 4 else 0x00
+
+# ---------------------------------------------------------------------------
+# ACK + SESSION HANDLING
+# ---------------------------------------------------------------------------
+
+def isPartOfSingleProgramDump(message):
+    if (len(message) == 6
+            and message[0] == 0xF0
+            and message[1] == 0x7E
+            and message[3] == 0x7E  # ACK byte
+            and message[5] == 0xF7):
+        return True  # absorb with no reply
+
+    if _is_fds(message, 0x01):
+        device_id = _fds_device_id(message)
+        return True, [0xF0, 0x7E, device_id, 0x7E, 0x00, 0xF7]
+
+    if _is_fds(message, 0x02):
+        device_id = _fds_device_id(message)
+        pkt_num = _fds_packet_num(message)
+        return True, [0xF0, 0x7E, device_id, 0x7E, pkt_num, 0xF7]
+
+    if _is_ubxa_eof(message):
+        device_id = message[2]
+        pkt_num = message[4]
+        return True, [0xF0, 0x7E, device_id, 0x7E, pkt_num, 0xF7]
+
+    return False
+
+def needsChannelSpecificDetection() -> bool:
+    return False
+    
+# ---------------------------------------------------------------------------
+# PROGRAM COMPLETION
+# ---------------------------------------------------------------------------
+
+def isSingleProgramDump(messages) -> bool:
+    if not hasattr(messages, '__len__'):
+        return False
+
+    all_msgs = _split_sysex(messages)
+    by_device = {}
+    for m in all_msgs:
+        if _is_fds(m, 0x01) or _is_fds(m, 0x02):
+            dev = _fds_device_id(m)
+            by_device.setdefault(dev, []).append(m)
+
+    has_eof = any(_is_ubxa_eof(m) for m in all_msgs)
+    for msgs in by_device.values():
+        has_header = any(_is_fds(m, 0x01) for m in msgs)
+        has_data = any(_is_fds(m, 0x02) for m in msgs)
+        if has_header and has_data and has_eof:
+            return True
+
+    return False
+
+# ---------------------------------------------------------------------------
+# RAW extraction 
+# ---------------------------------------------------------------------------
+
+def _fds_extract_raw(messages: List[List[int]]) -> List[int]:
+    pkts = [m for m in messages if _is_fds(m, 0x02)]
+    grouped = {}
+    for p in pkts:
+        dev = _fds_device_id(p)
+        grouped.setdefault(dev, []).append(p)
+
+    best = max(grouped.values(), key=len, default=[])
+    best.sort(key=lambda m: _fds_packet_num(m))
+
+    raw_encoded = []
+    for pkt in best:
+        # Start at _PL + 6 to skip the FDS padding byte. 
+        # End at -2 to skip the trailing FDS checksum byte and prevent cascading misalignment!
+        payload = pkt[_PL + 6 : -2]  
+        raw_encoded.extend(payload)
+
+    return list(unescape_sysex(raw_encoded))
+
+# ---------------------------------------------------------------------------
+# Device detection
+# ---------------------------------------------------------------------------
+
+def createDeviceDetectMessage(channel: int) -> List[int]:
+    filename_bytes = [ord(c) for c in "Globals         "] 
+    header = sysex_prefix + [0x7F, 0x74, 0x07, 0x03]
+    return header + _BIN_PREFIX + filename_bytes + _FW_VERSION + [sysex_suffix]
+
+def channelIfValidDeviceResponse(message: List[int]) -> int:
+    if _is_fds(message, 0x01):
+        return 0 
+    return -1
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+# Provide explicit bank descriptors with msb/lsb so KnobKraft knows how to send
+# the proper MIDI CC Bank Select messages before the Program Change!
+def bankDescriptors() -> List[dict]:
+    return [
+        {"bank": 0, "name": "Bank A", "size": 127, "msb": 0, "lsb": 0},  # was 128
+        {"bank": 1, "name": "Bank B", "size": 127, "msb": 0, "lsb": 1},  # was 128
+        {"bank": 2, "name": "Bank C", "size": 127, "msb": 0, "lsb": 2},  # was 128
+        {"bank": 3, "name": "Bank D", "size": 127, "msb": 0, "lsb": 3}   # was 128
+    ]
+
+def friendlyBankName(bank_number: int) -> str:
+    return "Bank " + chr(ord('A') + bank_number)
+    
+def bankSelect(channel, bank):
+    # CC#0 (MSB=0) + CC#32 (LSB=bank index 0-3 for A-D)
+    return [
+        0xB0 | (channel & 0x0f), 0,  0,     # Bank Select MSB = 0
+        0xB0 | (channel & 0x0f), 32, bank   # Bank Select LSB = bank
+    ]
+    
+def createCustomProgramChange(channel: int, patchNo: int) -> List[int]:
+    bank_letter = chr(ord('A') + (patchNo // 127))
+    patch_num = patchNo % 127
+    
+    filename = f"PatchX {bank_letter}{patch_num:03d}     "
+    filename_bytes = [ord(c) for c in filename]
+    
+    header = sysex_prefix + [0x7F, 0x74, 0x07, 0x03]
+    return header + _BIN_PREFIX + filename_bytes + _FW_VERSION + [sysex_suffix]
+    
+def friendlyProgramName(program: int) -> str:
+    bank = program // 127          # was 128
+    patch = (program % 127) + 1   # was % 128, now 1-indexed
+    return f"{chr(ord('A') + bank)}{patch:03d}"
+
+# ---------------------------------------------------------------------------
+# Dump requests
+# ---------------------------------------------------------------------------
+
+def createProgramDumpRequest(channel: int, patchNo: int) -> List[int]:
+    bank_letter = chr(ord('A') + (patchNo // 127))  # was 128
+    patch_num = (patchNo % 127) + 1                  # was % 128, now 1-indexed
+    
+    filename = f"PatchX {bank_letter}{patch_num:03d}     "
+    filename_bytes = [ord(c) for c in filename]
+    
+    header = sysex_prefix + [0x7F, 0x74, 0x07, 0x03]
+    return header + _BIN_PREFIX + filename_bytes + _FW_VERSION + [sysex_suffix]
+
+def convertToProgramDump(channel: int, patchNo: int, messages) -> List[int]:
+    result = []
+    for msg in _split_sysex(messages):
+        result.extend(msg)
+    return result
+
+def createEditBufferRequest(channel: int) -> List[int]:
+    filename = "Upper Patch     "
+    filename_bytes = [ord(c) for c in filename]
+    
+    header = sysex_prefix + [0x7F, 0x74, 0x07, 0x03]
+    return header + _BIN_PREFIX + filename_bytes + _FW_VERSION + [sysex_suffix]
+
+def _is_ubxa_eof(msg) -> bool:
+    return (len(msg) == 6
+            and msg[0] == 0xF0
+            and msg[1] == 0x7E
+            and msg[3] == 0x7B
+            and msg[4] == 0x00
+            and msg[5] == 0xF7)
+
+# ---------------------------------------------------------------------------
+# Dump parsing
+# ---------------------------------------------------------------------------
+
+def nameFromDump(messages) -> str:
+    all_msgs = _split_sysex(messages)
+    try:
+        raw = _fds_extract_raw(all_msgs)
+        if len(raw) >= 94:
+            chars = []
+            for i in range(8):
+                val = raw[78 + i * 2] | (raw[78 + i * 2 + 1] << 8)
+                
+                c_second = val & 0x7F        
+                c_first = (val >> 7) & 0x7F  
+                
+                if c_first == 0:
+                    break
+                chars.append(chr(c_first))
+                
+                if c_second == 0:
+                    break
+                chars.append(chr(c_second))
+                
+            name = ''.join(chars).strip()
+            if name:
+                return name
+    except Exception:
+        pass
+    return "Unknown"
+
+def numberFromDump(messages) -> int:
+    return -1
+
+def calculateFingerprint(messages) -> str:
+    try:
+        raw = _fds_extract_raw(_split_sysex(messages))
+        if len(raw) < 10:
+            return ""
+        data = bytearray(raw)
+        return hashlib.md5(data).hexdigest()
+    except Exception:
+        return ""
+
+# ---------------------------------------------------------------------------
+# Edit buffer
+# ---------------------------------------------------------------------------
+
+def isEditBufferDump(messages) -> bool:
+    return isSingleProgramDump(messages)
+
+def isPartOfEditBufferDump(message):
+    return isPartOfSingleProgramDump(message)
+
+def convertToEditBuffer(channel: int, messages) -> List[int]:
+    result = []
+    for msg in _split_sysex(messages):
+        msg = list(msg)
+        if _is_fds(msg, 0x01): # If this is the header packet
+            # Search for the BIN wrapper sequence: 7F 42 49 4E 20
+            bin_idx = -1
+            for i in range(len(msg) - 5):
+                if msg[i:i+5] == [0x7F, 0x42, 0x49, 0x4E, 0x20]:
+                    bin_idx = i
+                    break
+                    
+            # If found, the actual 16-byte filename starts 9 bytes after the wrapper
+            if bin_idx != -1 and bin_idx + 9 + 16 <= len(msg):
+                filename = "Upper Patch     "
+                filename_bytes = [ord(c) for c in filename]
+                # Overwrite the filename in the header packet
+                msg[bin_idx + 9 : bin_idx + 9 + 16] = filename_bytes
+                
+        result.extend(msg)
+    return result
+
+# ---------------------------------------------------------------------------
+# Rename
+# ---------------------------------------------------------------------------
+
+def renamePatch(messages, new_name: str) -> List[int]:
+    return list(messages)

--- a/adaptations/Casio CZ-101.py
+++ b/adaptations/Casio CZ-101.py
@@ -1,0 +1,198 @@
+#
+#   Adapted for Casio CZ-101 / CZ-1000 / CZ-5000
+#
+
+import hashlib
+import knobkraft
+from typing import Dict, List
+
+CASIO_ID = 0x44
+
+def name():
+    return "Casio CZ-101 / CZ-1000"
+
+def setupHelp():
+    return """
+The Casio CZ series uses a two-way handshake for SysEx dumps. 
+Ensure both MIDI IN and MIDI OUT are connected to your interface.
+SysEx must be enabled on the synthesizer (usually enabled by default).
+Note: CZ synthesizers do not store patch names internally.
+"""
+
+def createDeviceDetectMessage(channel):
+    # Command 0x10 is "Send Request" (Ask synth to send data to computer).
+    # We pack the 0x31 "Go Ahead" command into the exact same string to bypass the handshake!
+    return [0xF0, CASIO_ID, 0x00, 0x00, 0x70 | (channel & 0x0F), 0x10, 0x20, 0x70 | (channel & 0x0F), 0x31, 0xF7]
+
+def deviceDetectWaitMilliseconds():
+    return 200
+
+def needsChannelSpecificDetection():
+    return True
+
+def channelIfValidDeviceResponse(message):
+    # When we send a Send Request (0x10), the CZ responds with an ACK (0x30).
+    # We explicitly check for this ACK to avoid validating our own echoed requests (e.g., via IAC Bus).
+    if len(message) >= 6 and message[0] == 0xF0 and message[1] == CASIO_ID:
+        channel_byte = message[4]
+        command_byte = message[5]
+        
+        # 0x70 is the base channel identifier, 0x30 is the Casio ACK response
+        if (channel_byte & 0xF0) == 0x70 and command_byte == 0x30:
+            return channel_byte & 0x0F
+    return -1
+
+def bankDescriptors() -> List[Dict]:
+    # 0x20..0x2F (Internal 1-16) and 0x40..0x4F (Cartridge 1-16)
+    return [
+        {"bank": 0, "name": "Internal Sounds", "size": 16, "type": "Patch"},
+        {"bank": 1, "name": "Cartridge Sounds", "size": 16, "type": "Patch"}
+    ]
+
+def denibble_cz(data: List[int]) -> List[int]:
+    """
+    Casio CZ transmits bytes as two nibbles, LOW nibble first.
+    e.g., 0x5F is transmitted as 0x0F, 0x05.
+    """
+    unpacked_data = []
+    for i in range(0, len(data) - 1, 2):
+        byte = (data[i] & 0x0F) | ((data[i + 1] & 0x0F) << 4)
+        unpacked_data.append(byte)
+    return unpacked_data
+
+def nibble_cz(data: List[int]) -> List[int]:
+    """
+    Packs standard 8-bit bytes into Casio's Low-nibble, High-nibble format.
+    """
+    packed_data = []
+    for byte in data:
+        packed_data.append(byte & 0x0F)
+        packed_data.append((byte >> 4) & 0x0F)
+    return packed_data
+
+def isSingleProgramDump(message: List[int]) -> bool:
+    # A CZ single patch payload is 128 bytes sent as 256 nibbles + SysEx headers.
+    # The total length is typically 263 bytes.
+    if len(message) >= 263 and message[0] == 0xF0 and message[1] == CASIO_ID:
+        return True
+    return False
+
+def isEditBufferDump(message: List[int]) -> bool:
+    # The CZ edit buffer (temporary sound area) uses program number 0x60
+    return isSingleProgramDump(message)
+
+def convertToEditBuffer(channel, message):
+    if isEditBufferDump(message):
+        return message
+    if isSingleProgramDump(message):
+        # To send to the edit buffer, we'd need to format a "Receive Request 1" 
+        # targeting program 0x60, followed by the data. 
+        # This requires adjusting the header bytes depending on how KnobKraft handles the handshake.
+        return message
+    raise Exception("Can only convert single program dumps")
+
+def nameFromDump(message):
+    # CZ-101 patches do not contain ASCII name data. 
+    return "CZ Patch"
+
+def calculateFingerprint(message):
+    if isSingleProgramDump(message):
+        # Extract the payload (ignoring headers) to hash the actual patch data
+        index = knobkraft.sysex.findSysexDelimiters(message)
+        if len(index) > 0:
+            start, end = index[0]
+            # Strip standard headers and F7
+            payload = message[start+5:end-1]
+            return hashlib.md5(bytearray(payload)).hexdigest()
+    raise Exception("Can't calculate fingerprint of non-program dump message")
+
+# ==============================================================================
+# CZ-101 Parameter Mapping (256 bytes un-nibbled)
+# This dictionary maps parameter names to their byte offset in the 256-byte array.
+# Bitwise decoding/encoding would be needed for shared bytes (e.g. PFLAG).
+# ==============================================================================
+
+cz101_mapping = {
+    "PFLAG": 0,           # Line select, Octave range
+    "PDS": 1,             # Detune direction (0 = +, 1 = -)
+    "PDETL": 2,           # Detune fine data
+    "PDETH": 3,           # Detune octave and note data
+    "PVK": 4,             # Vibrato wave number
+    "PVDLD_1": 5,         # Vibrato delay (Byte 1)
+    "PVDLD_2": 6,         # Vibrato delay (Byte 2)
+    "PVDLV": 7,           # Vibrato delay (Byte 3)
+    "PVSD_1": 8,          # Vibrato rate (Byte 1)
+    "PVSD_2": 9,          # Vibrato rate (Byte 2)
+    "PVSV": 10,           # Vibrato rate (Byte 3)
+    "PVDD_1": 11,         # Vibrato depth (Byte 1)
+    "PVDD_2": 12,         # Vibrato depth (Byte 2)
+    "PVDV": 13,           # Vibrato depth (Byte 3)
+    "MFW_1": 14,          # DCO1 waveform (Byte 1)
+    "MFW_2": 15,          # DCO1 waveform (Byte 2)
+    "MAMD": 16,           # DCA1 key follow (Byte 1)
+    "MAMV": 17,           # DCA1 key follow (Byte 2)
+    "MWMD": 18,           # DCW1 key follow (Byte 1)
+    "MWMV": 19,           # DCW1 key follow (Byte 2)
+    "PMAL": 20,           # End step number of DCA1 envelope
+    # DCA1 Envelope Rate/Level (16 bytes starting at 21)
+    # ... Add remaining offsets sequentially based on the 25-section table ...
+}
+
+def load_cz_parameter(unpacked_msg, offset):
+    """Loads a parameter from the un-nibbled 256-byte array."""
+    return unpacked_msg[offset]
+
+def save_cz_parameter(unpacked_msg, offset, value):
+    """Saves a parameter to the un-nibbled 256-byte array."""
+    unpacked_msg[offset] = value
+    
+def messageTimings():
+    return {
+        # 263 bytes takes ~85ms to travel over MIDI. 
+        # 200ms gives the CZ-101 plenty of time to finish dumping before we ask for the next patch!
+        "generalMessageDelay": 300, 
+    }
+
+def createProgramDumpRequest(channel, patch_no):
+    # Map KnobKraft's 0-31 absolute index to CZ-101's internal program hex values
+    if 0 <= patch_no < 16:
+        # Bank 0 (Internal Sounds): 0x20 .. 0x2F
+        program_byte = 0x20 + patch_no
+    elif 16 <= patch_no < 32:
+        # Bank 1 (Cartridge Sounds): 0x40 .. 0x4F
+        program_byte = 0x40 + (patch_no - 16)
+    else:
+        raise Exception(f"Invalid patch number for CZ-101: {patch_no}")
+    
+    # 1. The Send Request (0x10) + 2. The Go Ahead Command (0x31)
+    # Packed tightly together into one illegal-but-effective 10-byte SysEx missile!
+    return [0xF0, CASIO_ID, 0x00, 0x00, 0x70 | (channel & 0x0F), 0x10, program_byte, 0x70 | (channel & 0x0F), 0x31, 0xF7]
+
+def createBankDumpRequest(channel, bank_id):
+    messages = []
+    # Bank 0 starts at index 0, Bank 1 (Cartridge) starts at index 16
+    start_patch = bank_id * 16
+    for i in range(16):
+        # Fire our blind handshake for each patch in the bank
+        messages.extend(createProgramDumpRequest(channel, start_patch + i))
+    return messages
+
+def isPartOfBankDump(message):
+    # Any valid individual patch dump we receive back counts as part of the bank
+    return isSingleProgramDump(message)
+
+def isBankDumpFinished(messages):
+    # 'messages' is a list of individual MIDI messages (List[List[int]])
+    # Count how many valid 263-byte patch dumps we've received so far.
+    valid_patches = sum(1 for msg in messages if isSingleProgramDump(msg))
+    return valid_patches >= 16
+
+def extractPatchesFromAllBankMessages(messages):
+    # KnobKraft hands us all the messages it collected. 
+    # We just filter out the valid patches and return them to be saved!
+    patches = []
+    for msg in messages:
+        if isSingleProgramDump(msg):
+            patches.append(msg)
+    
+    return patches

--- a/adaptations/Ensoniq Mirage (Soundprocess).py
+++ b/adaptations/Ensoniq Mirage (Soundprocess).py
@@ -1,0 +1,162 @@
+#
+#   KnobKraft ORM Adaptation for Ensoniq Mirage (SoundProcess OS)
+#
+#   SysEx structure derived from the Electra One template for this device.
+#
+#   All SysEx messages use the Ensoniq 3-byte manufacturer ID + device ID header:
+#       F0 00 00 23 01 ...
+#   (0x00 0x00 0x23 = Ensoniq manufacturer ID, 0x01 = device ID)
+#
+#   Key commands (from Electra One template):
+#       Computer Control ON:    F0 00 00 23 01 02 F7
+#       Read Patch (request):   F0 00 00 23 01 04 NN F7   (NN = patch 1-48)
+#       Write Patch (response): F0 00 00 23 01 44 NN [124 nybble bytes] F7
+#
+#   The 124 nybble bytes encode 62 raw parameter bytes (low nybble first, then
+#   high nybble), as confirmed by the Electra One response rules (byte indices 0-123).
+#
+#   Message length: 1(F0) + 5(header) + 1(patch#) + 124(data) + 1(F7) = 132 bytes
+#
+
+import hashlib
+
+
+def name():
+    return "Ensoniq Mirage (SoundProcess)"
+
+
+def setupHelp():
+    return (
+        "The Ensoniq Mirage must be booted with the SoundProcess OS disk.\n\n"
+        "Put the Mirage in Computer Control mode before use — the display should show 'CC'.\n"
+        "This adaptation will automatically send the CC activation command before each patch "
+        "request, but the Mirage may need a moment to switch modes.\n\n"
+        "If patch retrieval is unreliable, add a small inter-message delay in your MIDI "
+        "interface settings (50-100ms is usually sufficient).\n\n"
+        "SoundProcess supports 48 patches. Bank dump is not supported by the OS, so patches "
+        "are fetched one at a time.\n\n"
+        "Note: The SoundProcess patch dump does not include a patch name, so patches will be "
+        "identified by their slot number."
+    )
+
+
+def messageTimings():
+    return {
+        "generalMessageDelay": 300,
+        "deviceDetectWaitMilliseconds": 3000,
+        "replyTimeoutMs": 3000,
+    }
+
+
+def createDeviceDetectMessage(channel):
+    # This runs when KnobKraft is looking for the synth.
+    # We send CC ON (0x02) + a small "trash" request (0x04) to clear the buffer.
+    cc_command = [0xF0, 0x00, 0x00, 0x23, 0x01, 0x02, 0xF7]
+    read_patch = [0xF0, 0x00, 0x00, 0x23, 0x01, 0x04, 0x01, 0xF7]
+    return cc_command + read_patch
+
+
+def needsChannelSpecificDetection():
+    return False
+
+
+def channelIfValidDeviceResponse(message):
+    # During Auto-Detect, ONLY return 0 if we see the full 148-byte data.
+    # If we see the 8-byte ACK (0x00), return -1 to stay on the line.
+    if len(message) == 148 and message[0] == 0xF0 and message[5] == 0x44:
+        return 0
+    return -1
+    
+# ---------------------------------------------------------------------------
+# Edit buffer
+# SoundProcess has no dedicated edit buffer. Patch 1 is used as a stand-in.
+# ---------------------------------------------------------------------------
+
+def createEditBufferRequest(channel):
+    return createProgramDumpRequest(channel, 0)
+
+
+
+
+def convertToEditBuffer(channel, message):
+    # There is no edit buffer on the Mirage — sending a Write Patch command
+    # always targets the slot number embedded in the message header.
+    # We prepend the CC activation command to ensure the Mirage is ready.
+    if isSingleProgramDump(message):
+        cc_command = [0xF0, 0x00, 0x00, 0x23, 0x01, 0x02, 0xF7]
+        return cc_command + list(message)
+    return list(message)
+
+
+# ---------------------------------------------------------------------------
+# Single program dump
+# ---------------------------------------------------------------------------
+
+def createProgramDumpRequest(channel, program_number):
+    patch_num = (program_number % 48) + 1
+    cc_command = [0xF0, 0x00, 0x00, 0x23, 0x01, 0x02, 0xF7]
+    read_patch = [0xF0, 0x00, 0x00, 0x23, 0x01, 0x04, patch_num, 0xF7]
+    return cc_command + read_patch
+
+
+def isSingleProgramDump(message):
+    if not hasattr(message, '__len__'):
+        return False
+    return (len(message) == 148 and message[0] == 0xF0 and message[5] == 0x44)
+
+def calculateFingerprint(message):
+    # Hash the 140 bytes of actual parameter data (Index 7 to 146)
+    if len(message) == 148:
+        data = message[7:147]
+        return hashlib.md5(bytearray(data)).hexdigest()
+    return ""
+
+def numberFromDump(message):
+    # The Trace shows the patch number is at index 6.
+    # Mirage/SoundProcess uses 1-48, KnobKraft needs 0-47.
+    if len(message) == 148:
+        return message[6] - 1
+    return -1
+
+def nameFromDump(message):
+    if len(message) == 148:
+        return "Patch {}".format(message[6])
+    return "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+
+PATCHES_PER_BANK = 48
+
+def numberOfBanks():
+    return 48 // PATCHES_PER_BANK
+
+def numberOfPatchesPerBank():
+    return PATCHES_PER_BANK
+
+def createBankDumpRequest(channel, bank):
+    cc_command = [0xF0, 0x00, 0x00, 0x23, 0x01, 0x02, 0xF7]
+    messages = cc_command
+    start = bank * PATCHES_PER_BANK + 1
+    for patch_num in range(start, start + PATCHES_PER_BANK):
+        messages += [0xF0, 0x00, 0x00, 0x23, 0x01, 0x04, patch_num, 0xF7]
+    return messages
+    
+def isPartOfBankDump(message):
+    if not hasattr(message, '__len__'):
+        return False
+    return isSingleProgramDump(message)
+
+def isBankDumpFinished(messages):
+    try:
+        return sum(1 for m in messages if isSingleProgramDump(m)) >= PATCHES_PER_BANK
+    except TypeError:
+        return False
+        
+def extractPatchesFromBank(messages):
+    return messages
+    
+def friendlyBankName(bank_number):
+    return "Bank {}".format(bank_number + 1)


### PR DESCRIPTION
Hello!

Here are some additional adaptations - the soundprocess/mirage one seems to work quite well across the board, as does the Casio one in my testing. The UB-Xa one is still a work in progress - it pulls the patch data but clicking to switch patches on-device doesn't seem to be working yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Behringer UB-Xa synthesizer with complete patch management and bank selection
  * Added support for Casio CZ-101/CZ-1000/CZ-5000 synthesizers with bank dump functionality
  * Added support for Ensoniq Mirage (Soundprocess) with patch and bank operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->