### PR TITLE
Fix duplicate parsing of program-stream bank dumps

### DIFF
--- a/adaptations/test_librarian.py
+++ b/adaptations/test_librarian.py
@@ -59,3 +59,28 @@ def test_load_sysex_deduplicates_bank_patches_by_occurrence():
     patches = Librarian().load_sysex(PartiallyOverlappingBankAdaptation, messages)
 
     assert patches == [program_dump(0, 10), program_dump(1, 10)]
+
+
+class MutatingFingerprintBankAdaptation:
+    @staticmethod
+    def isPartOfBankDump(message):
+        return True
+
+    @staticmethod
+    def isBankDumpFinished(messages):
+        return len(messages) == 1
+
+    @staticmethod
+    def extractPatchesFromAllBankMessages(messages):
+        return [program_dump(0, 10)]
+
+    @staticmethod
+    def calculateFingerprint(message):
+        message[2] = 99
+        return str(message)
+
+
+def test_load_sysex_preserves_bank_patch_when_fingerprint_mutates_input():
+    patches = Librarian().load_sysex(MutatingFingerprintBankAdaptation, [[0xF0, 0x02, 0xF7]])
+
+    assert patches == [program_dump(0, 10)]

--- a/adaptations/test_librarian.py
+++ b/adaptations/test_librarian.py
@@ -99,10 +99,12 @@ class MutatingFingerprintEditBufferAdaptation:
 
 def test_load_sysex_preserves_edit_buffer_when_fingerprint_mutates_input():
     edit_buffer = [0xF0, 0x02, 0, 10, 0xF7]
+    expected_edit_buffer = edit_buffer.copy()
 
     patches = Librarian().load_sysex(MutatingFingerprintEditBufferAdaptation, [edit_buffer])
 
-    assert patches == [edit_buffer]
+    assert patches == [expected_edit_buffer]
+    assert edit_buffer == expected_edit_buffer
 
 
 class MutatingFingerprintBankAdaptation:

--- a/adaptations/test_librarian.py
+++ b/adaptations/test_librarian.py
@@ -61,6 +61,50 @@ def test_load_sysex_deduplicates_bank_patches_by_occurrence():
     assert patches == [program_dump(0, 10), program_dump(1, 10)]
 
 
+class MutatingFingerprintProgramAdaptation:
+    @staticmethod
+    def createProgramDumpRequest(channel, patch_no):
+        return []
+
+    @staticmethod
+    def isSingleProgramDump(message):
+        return len(message) == 5 and message[1] == 0x01
+
+    @staticmethod
+    def calculateFingerprint(message):
+        message[2] = 99
+        return str(message)
+
+
+def test_load_sysex_preserves_program_patch_when_fingerprint_mutates_input():
+    patches = Librarian().load_sysex(MutatingFingerprintProgramAdaptation, [program_dump(0, 10)])
+
+    assert patches == [program_dump(0, 10)]
+
+
+class MutatingFingerprintEditBufferAdaptation:
+    @staticmethod
+    def createEditBufferRequest(channel):
+        return []
+
+    @staticmethod
+    def isEditBufferDump(message):
+        return len(message) == 5 and message[1] == 0x02
+
+    @staticmethod
+    def calculateFingerprint(message):
+        message[2] = 99
+        return str(message)
+
+
+def test_load_sysex_preserves_edit_buffer_when_fingerprint_mutates_input():
+    edit_buffer = [0xF0, 0x02, 0, 10, 0xF7]
+
+    patches = Librarian().load_sysex(MutatingFingerprintEditBufferAdaptation, [edit_buffer])
+
+    assert patches == [edit_buffer]
+
+
 class MutatingFingerprintBankAdaptation:
     @staticmethod
     def isPartOfBankDump(message):

--- a/adaptations/test_librarian.py
+++ b/adaptations/test_librarian.py
@@ -1,0 +1,61 @@
+from testing.librarian import Librarian
+
+
+def program_dump(slot: int, sound: int):
+    return [0xF0, 0x01, slot, sound, 0xF7]
+
+
+class ProgramStreamBankAdaptation:
+    @staticmethod
+    def createProgramDumpRequest(channel, patch_no):
+        return []
+
+    @staticmethod
+    def isSingleProgramDump(message):
+        return len(message) == 5 and message[1] == 0x01
+
+    @staticmethod
+    def isPartOfBankDump(message):
+        return ProgramStreamBankAdaptation.isSingleProgramDump(message)
+
+    @staticmethod
+    def isBankDumpFinished(messages):
+        return len(messages) == 3
+
+    @staticmethod
+    def extractPatchesFromAllBankMessages(messages):
+        return messages
+
+    @staticmethod
+    def calculateFingerprint(message):
+        return str(message[3])
+
+
+def test_load_sysex_deduplicates_bank_stream_of_program_dumps():
+    messages = [program_dump(0, 10), program_dump(1, 11), program_dump(2, 12)]
+
+    patches = Librarian().load_sysex(ProgramStreamBankAdaptation, messages)
+
+    assert patches == messages
+
+
+class PartiallyOverlappingBankAdaptation(ProgramStreamBankAdaptation):
+    @staticmethod
+    def isPartOfBankDump(message):
+        return True
+
+    @staticmethod
+    def isBankDumpFinished(messages):
+        return len(messages) == 2
+
+    @staticmethod
+    def extractPatchesFromAllBankMessages(messages):
+        return [program_dump(0, 10), program_dump(1, 10)]
+
+
+def test_load_sysex_deduplicates_bank_patches_by_occurrence():
+    messages = [program_dump(0, 10), [0xF0, 0x02, 0xF7]]
+
+    patches = Librarian().load_sysex(PartiallyOverlappingBankAdaptation, messages)
+
+    assert patches == [program_dump(0, 10), program_dump(1, 10)]

--- a/adaptations/testing/librarian.py
+++ b/adaptations/testing/librarian.py
@@ -530,7 +530,7 @@ class Librarian:
             def append_bank_patches(patches: List[List[int]]) -> None:
                 for patch in patches:
                     if adaptation_has_implemented(adaptation, "calculateFingerprint"):
-                        patch_id = adaptation.calculateFingerprint(patch)
+                        patch_id = adaptation.calculateFingerprint(patch.copy())
                         unmatched_count = unmatched_program_dump_counts_by_id.get(patch_id, 0)
                         if unmatched_count > 0:
                             unmatched_program_dump_counts_by_id[patch_id] = unmatched_count - 1

--- a/adaptations/testing/librarian.py
+++ b/adaptations/testing/librarian.py
@@ -475,7 +475,7 @@ class Librarian:
 
     def load_sysex(self, adaptation, sysex_messages: List[List[int]]) -> List[List[int]]:
         results: List[List[int]] = []
-        program_dumps_by_id: Dict[str, List[int]] = {}
+        program_dump_counts_by_id: Dict[str, int] = {}
 
         if adaptation_has_program_dump_capability(adaptation):
             current_program_dumps: Deque[List[int]] = deque()
@@ -492,7 +492,8 @@ class Librarian:
                         patch = sliding_window
                         results.append(patch)
                         if adaptation_has_implemented(adaptation, "calculateFingerprint"):
-                            program_dumps_by_id[adaptation.calculateFingerprint(patch)] = patch
+                            patch_id = adaptation.calculateFingerprint(patch)
+                            program_dump_counts_by_id[patch_id] = program_dump_counts_by_id.get(patch_id, 0) + 1
                         current_program_dumps.clear()
 
         if adaptation_has_edit_buffer_capability(adaptation):
@@ -511,7 +512,7 @@ class Librarian:
                         patch = sliding_window
                         if adaptation_has_implemented(adaptation, "calculateFingerprint"):
                             patch_id = adaptation.calculateFingerprint(patch)
-                            if patch_id not in program_dumps_by_id:
+                            if patch_id not in program_dump_counts_by_id:
                                 results.append(patch)
                             else:
                                 # Ignore edit buffer, as we already loaded a program dump with the same ID
@@ -524,6 +525,18 @@ class Librarian:
             if adaptation_has_implemented(adaptation, "isPartOfBankDump"):
                 adaptation.isPartOfBankDump([])
             current_bank: Deque[List[int]] = deque()
+            unmatched_program_dump_counts_by_id = program_dump_counts_by_id.copy()
+
+            def append_bank_patches(patches: List[List[int]]) -> None:
+                for patch in patches:
+                    if adaptation_has_implemented(adaptation, "calculateFingerprint"):
+                        patch_id = adaptation.calculateFingerprint(patch)
+                        unmatched_count = unmatched_program_dump_counts_by_id.get(patch_id, 0)
+                        if unmatched_count > 0:
+                            unmatched_program_dump_counts_by_id[patch_id] = unmatched_count - 1
+                            continue
+                    results.append(patch)
+
             for message in sysex_messages:
                 # Try to parse and load these messages as a bank dump
                 is_part = adaptation_has_implemented(adaptation, "isPartOfBankDump") and handshake_flag(adaptation.isPartOfBankDump(message))
@@ -540,14 +553,14 @@ class Librarian:
                         if adaptation_has_implemented(adaptation, "extractPatchesFromAllBankMessages"):
                             more_patches = adaptation.extractPatchesFromAllBankMessages(sliding_window)
                             logging.info(f"Loaded bank dump with {len(more_patches)} patches")
-                            results.extend(more_patches)
+                            append_bank_patches(more_patches)
                             current_bank.clear()
                         else:
                             more_patches = adaptation.extractPatchesFromBank(sliding_window[0])
                             if more_patches:
                                 logging.info(f"Loaded bank dump from single message with {len(more_patches)} patches")
                                 split_patches = knobkraft.splitSysex(more_patches)
-                                results.extend(split_patches)
+                                append_bank_patches(split_patches)
                             current_bank.clear()
 
 

--- a/adaptations/testing/librarian.py
+++ b/adaptations/testing/librarian.py
@@ -492,7 +492,7 @@ class Librarian:
                         patch = sliding_window
                         results.append(patch)
                         if adaptation_has_implemented(adaptation, "calculateFingerprint"):
-                            patch_id = adaptation.calculateFingerprint(patch)
+                            patch_id = adaptation.calculateFingerprint(patch.copy())
                             program_dump_counts_by_id[patch_id] = program_dump_counts_by_id.get(patch_id, 0) + 1
                         current_program_dumps.clear()
 
@@ -511,7 +511,7 @@ class Librarian:
                     if adaptation.isEditBufferDump(sliding_window):
                         patch = sliding_window
                         if adaptation_has_implemented(adaptation, "calculateFingerprint"):
-                            patch_id = adaptation.calculateFingerprint(patch)
+                            patch_id = adaptation.calculateFingerprint(patch.copy())
                             if patch_id not in program_dump_counts_by_id:
                                 results.append(patch)
                             else:


### PR DESCRIPTION
## Summary

- deduplicate bank-extracted patches against program dumps parsed from the same SysEx input
- count matching fingerprints one-for-one so legitimate identical patches in different slots are preserved
- mirror the runtime behavior in the Python adaptation test librarian
- add regression tests for complete and partially overlapping program-stream bank dumps
- update MidiKraft to the single fix commit from [MidiKraft PR #8](https://github.com/christofmuc/MidiKraft/pull/8)

The submodule fix is based directly on the MidiKraft revision currently pinned by Orm, so this PR does not include the previously reverted update to newer MidiKraft `main` commits.

Closes #555.

## Validation

- `test_librarian.py`: 2 passed
- `Moog_Voyager.py`: 19 passed, 17 skipped
- `Korg_M1.py`: 11 passed, 25 skipped
- `RolandD50.py`: 23 passed, 13 skipped
- `KawaiK5000.py`: 15 passed, 21 skipped
- Visual Studio 2022 Debug build of `midikraft-base`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SysEx patch loading to correctly retain duplicate patches based on their occurrence count.
  * Prevented edit-buffer patches from being duplicated when a matching program dump is already present.
  * Improved bank-dump filtering so only matching patches already loaded are excluded, while additional duplicates are preserved.
  * Ensured patch data remains unchanged during fingerprinting, improving the reliability of loaded program, edit-buffer, and bank patches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->