### PR TITLE
Prevent crashes when sending empty user banks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,7 @@ if(BUILD_PATCH_DATABASE_TESTS)
 		tests/patch_list_fill_test.cpp
 		tests/patch_database_search_test.cpp
 		tests/user_bank_save_test.cpp
+		tests/bank_send_test.cpp
 		tests/test_helpers.h
 		The-Orm/UserBankFactory.cpp)
 	target_include_directories(patch_database_migration_test PRIVATE

--- a/The-Orm/PatchView.cpp
+++ b/The-Orm/PatchView.cpp
@@ -459,11 +459,16 @@ void PatchView::downloadBanksFromSynth(std::shared_ptr<midikraft::Synth> synth,
 void PatchView::sendBankToSynth(std::shared_ptr<midikraft::SynthBank> bankToSend, bool ignoreDirty, std::function<void()> finishedHandler)
 {
 	if (!bankToSend) return;
+	if (bankToSend->hasEmptySlots()) {
+		AlertWindow::showMessageBox(juce::AlertWindow::AlertIconType::WarningIcon, "Bank has empty slots",
+			"Fill all slots with patches before sending this bank to the synth. No patches have been sent.");
+		return;
+	}
 
 	auto device = std::dynamic_pointer_cast<midikraft::DiscoverableDevice>(bankToSend->synth());
 	auto location = midikraft::Capability::hasCapability<midikraft::MidiLocationCapability>(bankToSend->synth());
 	if (location) {
-		if (location->channel().isValid() && device->wasDetected()) {
+		if (location->channel().isValid() && device && device->wasDetected()) {
 			auto progressWindow = std::make_shared<LibrarianProgressWindow>(librarian_, "Sending bank to Synth");
 			progressWindow->setMessage("Starting send");
 			if (bankToSend->synth() /*&& device->wasDetected()*/) {

--- a/adaptations/GenericEditBufferCapability.cpp
+++ b/adaptations/GenericEditBufferCapability.cpp
@@ -111,6 +111,10 @@ namespace knobkraft {
 
 	std::vector<juce::MidiMessage> GenericEditBufferCapability::patchToSysex(std::shared_ptr<midikraft::DataFile> patch) const
 	{
+		if (!patch) {
+			spdlog::warn("Cannot convert an empty patch to an edit buffer dump");
+			return {};
+		}
 		py::gil_scoped_acquire acquire;
 		try {
 			auto data = patch->data();

--- a/adaptations/GenericProgramDumpCapability.cpp
+++ b/adaptations/GenericProgramDumpCapability.cpp
@@ -138,6 +138,10 @@ namespace knobkraft {
 
 	std::vector<juce::MidiMessage> GenericProgramDumpCapability::patchToProgramDumpSysex(std::shared_ptr<midikraft::DataFile> patch, MidiProgramNumber programNumber) const
 	{
+		if (!patch) {
+			spdlog::warn("Cannot convert an empty patch to a program dump");
+			return {};
+		}
 		py::gil_scoped_acquire acquire;
 		try
 		{

--- a/tests/bank_send_test.cpp
+++ b/tests/bank_send_test.cpp
@@ -1,0 +1,115 @@
+#include "doctest/doctest.h"
+
+#include "BankDumpCapability.h"
+#include "GenericEditBufferCapability.h"
+#include "GenericProgramDumpCapability.h"
+#include "Librarian.h"
+#include "MidiLocationCapability.h"
+#include "ProgramDumpCapability.h"
+#include "test_helpers.h"
+
+namespace {
+
+// Exercise the real librarian without opening a MIDI device.
+class SendTestSynth : public test_helpers::DummySynth,
+	public midikraft::MidiLocationCapability, public midikraft::ProgramDumpCabability {
+public:
+	SendTestSynth() : DummySynth("SendTestSynth", 2) {}
+
+	MidiChannel channel() const override { return MidiChannel::fromZeroBase(0); }
+	juce::MidiDeviceInfo midiInput() const override { return {}; }
+	juce::MidiDeviceInfo midiOutput() const override { return {}; }
+	std::vector<MidiMessage> requestPatch(int) const override { return {}; }
+	bool isSingleProgramDump(const std::vector<MidiMessage>&) const override { return true; }
+	MidiProgramNumber getProgramNumber(const std::vector<MidiMessage>&) const override {
+		return MidiProgramNumber::fromZeroBase(0);
+	}
+	std::shared_ptr<midikraft::DataFile> patchFromProgramDumpSysex(const std::vector<MidiMessage>&) const override {
+		return nullptr;
+	}
+	std::vector<MidiMessage> patchToProgramDumpSysex(std::shared_ptr<midikraft::DataFile> patch, MidiProgramNumber number) const override {
+		++conversions;
+		CHECK(patch != nullptr);
+		programs.push_back(number.toZeroBasedWithBank());
+		return { MidiMessage::programChange(1, number.toZeroBasedWithBank()) };
+	}
+	void sendBlockOfMessagesToSynth(juce::MidiDeviceInfo const&, std::vector<MidiMessage> const& messages) override {
+		sentMessages += messages.size();
+	}
+
+	mutable int conversions = 0;
+	mutable std::vector<int> programs;
+	size_t sentMessages = 0;
+};
+
+class BankSendTestSynth : public SendTestSynth, public midikraft::BankSendCapability {
+public:
+	std::vector<MidiMessage> createBankMessages(std::vector<std::vector<MidiMessage>> patches) override {
+		++bankConversions;
+		std::vector<MidiMessage> result;
+		for (auto const& patch : patches) {
+			result.insert(result.end(), patch.begin(), patch.end());
+		}
+		return result;
+	}
+	int bankConversions = 0;
+};
+
+} // namespace
+
+TEST_CASE("generic converters reject null patches without entering Python") {
+	knobkraft::GenericProgramDumpCapability programConverter(nullptr);
+	CHECK(programConverter.patchToProgramDumpSysex(nullptr, MidiProgramNumber::fromZeroBase(0)).empty());
+	knobkraft::GenericEditBufferCapability editBufferConverter(nullptr);
+	CHECK(editBufferConverter.patchToSysex(nullptr).empty());
+}
+
+TEST_CASE("incomplete banks are rejected before any conversion or MIDI output") {
+	std::shared_ptr<SendTestSynth> synth;
+	SUBCASE("individual program dumps") { synth = std::make_shared<SendTestSynth>(); }
+	SUBCASE("whole bank messages") { synth = std::make_shared<BankSendTestSynth>(); }
+	REQUIRE(synth);
+	midikraft::UserBank bank("test-bank", "Test bank", synth, MidiBankNumber::fromZeroBase(0, 2));
+	auto patch = test_helpers::makePatchHolder(synth, "Valid first patch", { 1, 2 });
+	// The first slot is valid: validation must catch the later empty slot before sending it.
+	bank.setPatches({});
+	bank.updatePatchAtPosition(MidiProgramNumber::fromZeroBaseWithBank(bank.bankNumber(), 0), patch);
+	REQUIRE(bank.isDirty());
+	midikraft::Librarian librarian({});
+	for (bool fullBank : { true, false }) {
+		int callbacks = 0;
+		librarian.sendBankToSynth(bank, fullBank, nullptr, [&](bool completed) {
+			++callbacks;
+			CHECK_FALSE(completed);
+		});
+		CHECK(callbacks == 1);
+		CHECK(synth->conversions == 0);
+		CHECK(synth->sentMessages == 0);
+		CHECK(bank.isDirty());
+	}
+	if (auto bankSynth = std::dynamic_pointer_cast<BankSendTestSynth>(synth)) {
+		CHECK(bankSynth->bankConversions == 0);
+	}
+	// No callback is also a supported caller.
+	librarian.sendBankToSynth(bank, true, nullptr, {});
+}
+
+TEST_CASE("populated banks still send successfully") {
+	std::shared_ptr<SendTestSynth> synth;
+	SUBCASE("individual program dumps") { synth = std::make_shared<SendTestSynth>(); }
+	SUBCASE("whole bank messages") { synth = std::make_shared<BankSendTestSynth>(); }
+	REQUIRE(synth);
+	midikraft::UserBank bank("test-bank", "Test bank", synth, MidiBankNumber::fromZeroBase(0, 2));
+	auto patch = test_helpers::makePatchHolder(synth, "Patch", { 1, 2 });
+	bank.setPatches({ patch, patch });
+	midikraft::Librarian librarian({});
+	int callbacks = 0;
+	librarian.sendBankToSynth(bank, true, nullptr, [&](bool completed) {
+		++callbacks;
+		CHECK(completed);
+	});
+	CHECK(callbacks == 1);
+	CHECK(synth->conversions == 2);
+	CHECK(synth->sentMessages == 2);
+	CHECK(synth->programs == std::vector<int>{ 0, 1 });
+}

--- a/tests/user_bank_save_test.cpp
+++ b/tests/user_bank_save_test.cpp
@@ -3,6 +3,7 @@
 #include "PatchDatabase.h"
 #include "PatchListType.h"
 #include "SynthBank.h"
+#include "Librarian.h"
 #include "The-Orm/UserBankFactory.h"
 #include "test_helpers.h"
 
@@ -201,4 +202,29 @@ TEST_CASE("user bank factory creates user bank list entries") {
 	listQuery.bind(":ID", bank->id().c_str());
 	REQUIRE(listQuery.executeStep());
 	CHECK(listQuery.getColumn(0).getInt() == midikraft::PatchListType::USER_BANK);
+}
+
+TEST_CASE("sending a saved and reloaded empty user bank fails safely") {
+	auto tmp = makeTempDatabasePath();
+	midikraft::PatchDatabase db(tmp.path().string(), midikraft::PatchDatabase::OpenMode::READ_WRITE);
+	auto synth = std::make_shared<DummySynth>("DummySynth", 8);
+	auto bank = knobkraft::createUserBank(synth, 0, "Empty bank");
+	db.putPatchList(bank);
+
+	std::map<std::string, std::weak_ptr<midikraft::Synth>> synthMap;
+	synthMap[synth->getName()] = synth;
+	auto reloaded = std::dynamic_pointer_cast<midikraft::SynthBank>(db.getPatchList({ bank->id(), bank->name() }, synthMap));
+	REQUIRE(reloaded);
+	REQUIRE(reloaded->patches().size() == 8);
+	for (auto const& patch : reloaded->patches()) {
+		REQUIRE_FALSE(patch.patch());
+	}
+
+	midikraft::Librarian librarian({});
+	int callbacks = 0;
+	librarian.sendBankToSynth(*reloaded, true, nullptr, [&](bool completed) {
+		++callbacks;
+		CHECK_FALSE(completed);
+	});
+	CHECK(callbacks == 1);
 }


### PR DESCRIPTION
Sending a newly created user bank can dereference a null placeholder patch before any SysEx is transmitted. Reject empty or incomplete banks before starting an upload and tell the user to fill every slot. Add defensive null checks to both generic patch converters and to the discovered-device check.

Closes #548.

Includes the merged fix from https://github.com/christofmuc/MidiKraft/pull/11, which adds shared bank validation and rejects incomplete banks before any conversion or MIDI output. The submodule now points to merge commit c5ba4d4ac54e89e4cc711cf5a4fea65711cbd901; its contents are identical to the tested dependency commit.

Regression coverage includes saving/reloading an empty user bank, null input to both converters without entering Python, an incomplete bank whose first patch is valid, and successful sends of populated banks. Mock MIDI checks cover both program-dump and whole-bank conversion paths and confirm rejected uploads preserve dirty state and invoke failure callbacks.

Validation in the implementation workspace:

- 19 database/save-reload tests passed (1,327 assertions).
- 3 additional converter/bank-send tests passed (43 assertions).
- Changed librarian and adaptation libraries built successfully with the WSL C++ toolchain; the changed PatchView UI file also compiled.
- After porting to current default branches, verified the tested implementation and regression sources were unchanged, apart from line endings. Preserved the current branch's existing test dependencies and checked both PR diffs for whitespace errors.

The original macOS/R3 crash has not been reproduced on hardware; this hardens the concrete null-pointer path identified from the report and code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented sending incomplete or empty banks to synthesizers, with a clear warning and failure status.
  - Improved handling when a synthesizer is unavailable or undetected.
  - Safely handle missing patches during message conversion without crashes.

- **Tests**
  - Added coverage for valid bank transfers, rejected incomplete banks, empty saved banks, and null patch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->