### PR TITLE
Preserve Trigon-6 custom names when reimporting Basic Program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,7 @@ if(BUILD_PATCH_DATABASE_TESTS)
 		tests/patch_database_search_test.cpp
 		tests/user_bank_save_test.cpp
 		tests/bank_send_test.cpp
+		tests/trigon_rename_test.cpp
 		tests/test_helpers.h
 		The-Orm/UserBankFactory.cpp)
 	target_include_directories(patch_database_migration_test PRIVATE

--- a/adaptations/Sequential_Trigon6.py
+++ b/adaptations/Sequential_Trigon6.py
@@ -24,6 +24,11 @@ synth = sequential.GenericSequential(name="Sequential Trigon-6",
                                      ).install(this_module)
 
 
+def isDefaultName(patch_name):
+    # Keep a name assigned in the librarian when the synth still sends its default.
+    return patch_name.strip() == "Basic Program"
+
+
 # Test data picked up by test_adaptation.py
 def make_test_data():
     def programs(data: testing.TestData) -> List[testing.ProgramTestData]:

--- a/adaptations/test_Sequential_Trigon6.py
+++ b/adaptations/test_Sequential_Trigon6.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+import knobkraft
+import Sequential_Trigon6 as trigon
+
+
+@pytest.mark.parametrize("name", ["Basic Program", "Basic Program       "])
+def test_basic_program_is_a_default_name(name):
+    assert trigon.isDefaultName(name)
+
+
+@pytest.mark.parametrize("name", ["084 CCJ Brass", "Basic Program 2", "Dakota Chorale"])
+def test_custom_names_are_not_default_names(name):
+    assert not trigon.isDefaultName(name)
+
+
+def test_renaming_a_bank_preserves_order_addresses_and_fingerprints():
+    fixture = Path(__file__).parent / "testData" / "Sequential_Trigon6" / "T6_Programs_v1.0.syx"
+    programs = knobkraft.load_sysex(str(fixture))
+    assert len(programs) == 500
+    # Exercise every slot, including 80-85 from #543, in both dump formats.
+    for slot, program in enumerate(programs[:100]):
+        assert trigon.numberFromDump(program) == slot
+        fingerprint = trigon.calculateFingerprint(program)
+        for source in [program, trigon.convertToEditBuffer(0, program)]:
+            renamed = trigon.renamePatch(source, f"{slot:03} CCJ Brass")
+            assert trigon.nameFromDump(renamed) == f"{slot:03} CCJ Brass"
+            assert trigon.calculateFingerprint(renamed) == fingerprint
+            restored = trigon.convertToProgramDump(0, renamed, slot)
+            assert trigon.numberFromDump(restored) == slot
+            assert trigon.nameFromDump(restored) == f"{slot:03} CCJ Brass"
+            assert trigon.calculateFingerprint(restored) == fingerprint

--- a/tests/trigon_rename_test.cpp
+++ b/tests/trigon_rename_test.cpp
@@ -1,0 +1,58 @@
+#include "doctest/doctest.h"
+
+#include "GenericAdaptation.h"
+#include "PatchDatabase.h"
+#include "Sysex.h"
+
+#include <pybind11/embed.h>
+
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+TEST_CASE("Trigon-6 reimport preserves custom names over Basic Program") {
+	pybind11::scoped_interpreter python;
+	auto adaptationsPath = std::filesystem::path(KNOBKRAFT_TEST_SOURCE_DIR) / "adaptations";
+	pybind11::module_::import("sys").attr("path").attr("insert")(0, adaptationsPath.string());
+	auto synth = std::make_shared<knobkraft::GenericAdaptation>("Sequential_Trigon6");
+	auto fixture = Sysex::loadSysex((adaptationsPath / "testData" / "Sequential_Trigon6" / "T6_Programs_v1.0.syx").string());
+	REQUIRE(fixture.size() == 500);
+
+	// Load separate copies, as PatchHolder::setName also modifies the patch data.
+	auto makePatch = [&]() {
+		auto patches = synth->loadSysex({ fixture[84] });
+		REQUIRE(patches.size() == 1);
+		auto source = std::make_shared<midikraft::FromFileSource>(
+			"T6_Programs_v1.0.syx", (adaptationsPath / "testData" / "Sequential_Trigon6" / "T6_Programs_v1.0.syx").string(),
+			MidiProgramNumber::fromZeroBase(84));
+		return midikraft::PatchHolder(synth, source, patches.front());
+	};
+	auto renamed = makePatch();
+	auto originalFingerprint = renamed.md5();
+	renamed.setName("084 CCJ Brass");
+	REQUIRE(renamed.name() == "084 CCJ Brass");
+	REQUIRE(renamed.md5() == originalFingerprint);
+
+	midikraft::PatchDatabase db(":memory:", midikraft::PatchDatabase::OpenMode::READ_WRITE);
+	db.putPatch(renamed);
+	auto incoming = makePatch();
+	incoming.setName("Basic Program");
+	REQUIRE(incoming.name() == "Basic Program");
+	REQUIRE(incoming.md5() == originalFingerprint);
+
+	auto reimport = [&](midikraft::PatchHolder patch) {
+		std::vector<midikraft::PatchHolder> patches{ patch }, added;
+		db.mergePatchesIntoDatabase(patches, added, nullptr,
+			midikraft::PatchDatabase::UPDATE_NAME | midikraft::PatchDatabase::UPDATE_CATEGORIES | midikraft::PatchDatabase::UPDATE_FAVORITE);
+		CHECK(added.empty());
+		std::vector<midikraft::PatchHolder> stored;
+		REQUIRE(db.getSinglePatch(synth, originalFingerprint, stored));
+		REQUIRE(stored.size() == 1);
+		return stored.front();
+	};
+	CHECK(reimport(incoming).name() == "084 CCJ Brass");
+
+	// Ordinary names from the synth must still be accepted on reimport.
+	incoming.setName("New Brass");
+	CHECK(reimport(incoming).name() == "New Brass");
+}


### PR DESCRIPTION
Reimporting a Trigon-6 sound named `Basic Program` overwrites the custom name previously assigned in KnobKraft. The adaptation did not implement `isDefaultName`, so the database's existing protection for manually assigned names was never applied. Recognize the default name (including padding spaces), while continuing to accept ordinary name changes from the synth.

This addresses the name-loss follow-up in #543: https://github.com/christofmuc/KnobKraft-orm/issues/543#issuecomment-4608990477. It is a partial fix and intentionally leaves the issue open. The originally reported skipped/misaligned rename rows were not reproduced with the available factory bank. Investigating that symptom still needs the reporter's bank ZIP and the exact application version/workflow, ideally with the database state before import; the issue mentions an emailed ZIP but has no public bank attachment.

Validation:

- Added a C++ regression using the real Trigon-6 adaptation, a factory patch and PatchDatabase's import merge flags. Before this change it reproduced `084 CCJ Brass` being overwritten by `Basic Program`; afterward all 15 assertions pass, including accepting a subsequent `New Brass` name. Registered the test in `BUILD_PATCH_DATABASE_TESTS`.
- `python -m pytest test_Sequential_Trigon6.py test_adaptations.py --adaptation Sequential_Trigon6.py -q` from `adaptations`: 17 passed, 23 skipped for unavailable capabilities/fixtures. The new bank test covers all 100 slots in program and edit-buffer formats, preserving names, program addresses and fingerprints.
- The C++ regression was compiled and run standalone in WSL against cached project libraries, with the Python bridge translation unit rebuilt from master. A full application rebuild and hardware test were not performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved custom patch names when reimporting Sequential Trigon-6 patches, preventing the default “Basic Program” name from overwriting assigned names.

* **Tests**
  * Added coverage for default-name detection, patch renaming across program slots, ordering, addresses, fingerprints, and reimport behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->