### PR TITLE
Document Nix installation on Ubuntu and other Linux distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,23 @@ I provide installer builds for Windows and disk images for macOS, they are hoste
 
 [https://github.com/christofmuc/KnobKraft-orm/releases](https://github.com/christofmuc/KnobKraft-orm/releases)
 
-Linux is reported to build and run as well, but due to the multitude of possible installations I suggest you follow the build instructions below, it shouldn't be too hard.
+Linux builds are available on the release page. You can also try the community-maintained Nix package described below, or follow the [Linux build instructions](#building-on-linux).
 
 You can always use the source to build it yourself, please read on for more instructions.
+
+## Installing on Linux with Nix
+
+KnobKraft Orm is available in [Nixpkgs](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/kn/knobkraft-orm), thanks to package maintainer [@backtail](https://github.com/backtail). Nix can be used on Ubuntu and other Linux distributions as well as NixOS; switching your operating system is not necessary.
+
+After [installing the Nix package manager](https://nixos.org/download/), try Orm with:
+
+```sh
+nix --extra-experimental-features 'nix-command flakes' run nixpkgs#knobkraft-orm
+```
+
+Nix provides the package's dependencies and downloads prebuilt packages when available, or builds them from source. The packaged version depends on your selected Nixpkgs revision and may lag behind our latest release.
+
+This is a possible route for Ubuntu users whose downloaded release binary has incompatible system libraries. Orm's GUI and MIDI operation through Nix on Ubuntu have not yet been verified by the project. Graphics drivers may need additional integration such as [nixGL](https://github.com/nix-community/nixGL), and MIDI devices must be accessible to your Linux user. Please report your distribution, package version and MIDI interface when sharing results.
 
 ## Supported platforms
 


### PR DESCRIPTION
Document the community-maintained Nixpkgs package as a possible installation route on Ubuntu and other Linux distributions, with an executable example and credit to the package maintainer.

Explain that the packaged release may lag upstream and that the project's GUI/MIDI testing on Ubuntu is still outstanding. Link to Nix installation and nixGL guidance, and retain the native build instructions.

Validation: checked the existing Nixpkgs recipe and Nix documentation; `git diff --check` passes. No Ubuntu GUI or hardware MIDI success is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Linux installation guidance to point to available builds on the release page and a community-maintained Nix package.
  - Added instructions for running the application through Nix.
  - Documented potential version lag, GUI/MIDI compatibility considerations, nixGL requirements, and MIDI device access setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->