### PR TITLE
Fix Nord Lead MIDI import and remaining PR #559 review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Questions and help with implementing new synths wanted! Or if you have found a b
 | Behringer | Wave | works | adaptation | Thanks to @willxy! |
 | Black Corporation | Kijimi | beta | adaptation | Thanks to @ffont and @markusschlosser |
 | Casio | CZ-101/CZ-1000 | alpha | adaptation | Contributed by @Casuallynoted; hardware validation needed |
-| Clavia | Nord Lead / Nord Lead 2 / Nord Lead 2X | alpha | adaptation | Four live banks; ten-bank 2X file import/export; official fixtures and mock MIDI tested, hardware verification pending; no Nord Lead 3+ |
+| Clavia | Nord Lead / Nord Lead 2 / Nord Lead 2X | alpha | adaptation | Four documented live-request banks (availability depends on model and installed memory card); ten-bank 2X file import/export; official fixtures and mock MIDI tested, hardware verification pending; no Nord Lead 3+ |
 | DSI | Evolver | beta | adaptation | |
 | DSI | Mopho | works | adaptation | |
 | DSI | Mopho X4 | works | adaptation | |

--- a/adaptations/Clavia_Nord_Lead.py
+++ b/adaptations/Clavia_Nord_Lead.py
@@ -284,6 +284,8 @@ def _extract_sysex_from_midi_bytes(data: bytes) -> List[List[int]]:
                         elif escaped:
                             escaped.append(byte)
                             if byte == 0xF7:
+                                if any(data_byte >= 0x80 for data_byte in escaped[1:-1]):
+                                    raise ValueError("Embedded status byte in MIDI SysEx")
                                 messages.append(escaped)
                                 escaped = []
                     if escaped:

--- a/adaptations/test_Clavia_Nord_Lead.py
+++ b/adaptations/test_Clavia_Nord_Lead.py
@@ -152,8 +152,8 @@ def vlq(value):
 EOT = b"\x00\xff\x2f\x00"
 
 
-def smf(*tracks, format=0):
-    return (b"MThd\x00\x00\x00\x06" + format.to_bytes(2, "big")
+def smf(*tracks, smf_format=0):
+    return (b"MThd\x00\x00\x00\x06" + smf_format.to_bytes(2, "big")
             + len(tracks).to_bytes(2, "big") + b"\x00\x60"
             + b"".join(b"MTrk" + len(t).to_bytes(4, "big") + t for t in tracks))
 
@@ -174,11 +174,11 @@ def test_midi_complete_split_and_escaped_sysex(patch):
     assert nord.loadPatchesFromLegacyData(list(smf(event(0xF7, patch[1:]) + EOT))) == []
 
 
-@pytest.mark.parametrize("format", [1, 2])
-def test_midi_multiple_tracks_and_channel_running_status(patch, format):
+@pytest.mark.parametrize("smf_format", [1, 2])
+def test_midi_multiple_tracks_and_channel_running_status(patch, smf_format):
     channel_events = b"\x00\x90\x3c\x40\x00\x3d\x41\x00\xc0\x01\x00\x02\x00\xd0\x30"
     meta = b"\x00\xff\x01\x03abc"
-    data = smf(channel_events + meta + EOT, event(0xF0, patch[1:]) + EOT, format=format)
+    data = smf(channel_events + meta + EOT, event(0xF0, patch[1:]) + EOT, smf_format=smf_format)
     assert nord.loadPatchesFromLegacyData(list(data)) == [patch]
 
 
@@ -201,6 +201,19 @@ def test_malformed_tracks_raise_value_error(track):
         nord.loadPatchesFromLegacyData(list(smf(track)))
 
 
+@pytest.mark.parametrize("status", [0x80, 0x90, 0xF1, 0xF8, 0xFF])
+@pytest.mark.parametrize("same_escape", [False, True])
+def test_malformed_escaped_sysex_never_returns_partial_patches(patch, status, same_escape):
+    malformed = patch.copy()
+    malformed[6] = status
+    if same_escape:
+        track = event(0xF7, patch + malformed)
+    else:
+        track = event(0xF0, patch[1:]) + event(0xF7, malformed)
+    with pytest.raises(ValueError, match="Embedded status byte in MIDI SysEx"):
+        nord.loadPatchesFromLegacyData(list(smf(track + EOT)))
+
+
 def test_bad_headers_and_truncations_never_return_partial_patches(patch):
     good = smf(event(0xF0, patch[1:]) + EOT)
     for length in range(4, len(good)):
@@ -208,9 +221,9 @@ def test_bad_headers_and_truncations_never_return_partial_patches(patch):
             nord.loadPatchesFromLegacyData(list(good[:length]))
     for malformed in [
         good + b"extra", good[:4] + b"\x00\x00\x00\x05" + good[8:],
-        smf(EOT, format=3), smf(), smf(EOT, EOT),
+        smf(EOT, smf_format=3), smf(), smf(EOT, EOT),
         smf(event(0xF0, patch[1:]) + b"\x00\xf0\x7f" + EOT),
-        smf(EOT, b"\x00\x3c\x40" + EOT, format=1),
+        smf(EOT, b"\x00\x3c\x40" + EOT, smf_format=1),
     ]:
         with pytest.raises(ValueError):
             nord.loadPatchesFromLegacyData(list(malformed))

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Questions and help with implementing new synths wanted! Or if you have found a b
 | Behringer | RD-8 | in progress | adaptation | |
 | Behringer | RD-9 | in progress | adaptation | |
 | Black Corporation | Kijimi | in progress | adaptation | Thanks to @ffont|
-| Clavia | Nord Lead / Nord Lead 2 / Nord Lead 2X | alpha | adaptation | Four live banks; ten-bank 2X file import/export; official fixtures and mock MIDI tested, hardware verification pending; no Nord Lead 3+ |
+| Clavia | Nord Lead / Nord Lead 2 / Nord Lead 2X | alpha | adaptation | Four documented live-request banks (availability depends on model and installed memory card); ten-bank 2X file import/export; official fixtures and mock MIDI tested, hardware verification pending; no Nord Lead 3+ |
 | DSI | Evolver | beta | adaptation | |
 | DSI | Mopho | works | adaptation | |
 | DSI | Mopho X4 | works | adaptation | |


### PR DESCRIPTION
Nord Lead MIDI imports could silently return only earlier valid patches when an F7 escape contained an explicitly framed SysEx message with an embedded status byte. Validate those messages before collecting them and raise ValueError for the malformed file.

Addresses the three outstanding CodeRabbit findings from #559:
- Reject malformed escaped SysEx, with ten regression cases covering five status bytes and valid patches in the same or an earlier event.
- Rename both test parameters from format to smf_format, including all callers.
- Clarify model/memory-card-dependent live-bank availability in both device tables, preserving ten-bank 2X file import/export support.

The earlier request-ID finding was already settled in #559; the documented 0x0B-0x0E range remains correct.

Validation: Python 3.12, Nord Lead generic and dedicated tests: 125 passed, 10 expected skips for unsupported optional adaptation capabilities. All ten new cases failed before the parser fix and pass afterward. Existing valid escaped, fragmented, and official MIDI fixture imports pass. git diff --check is clean. Hardware behavior was not tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed MIDI SysEx messages containing embedded status bytes are now rejected with a clear error instead of producing incomplete patch data.

- **Documentation**
  - Updated Clavia Nord Lead compatibility information to describe four documented live-request banks.
  - Clarified that memory-card availability depends on the specific model and installed memory card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->