### PR TITLE
Add MIDI loopback test dialog

### DIFF
--- a/The-Orm/CMakeLists.txt
+++ b/The-Orm/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SOURCES
 	MacroConfig.cpp MacroConfig.h
 	MainComponent.h MainComponent.cpp	
 	Main.cpp
+	MidiLoopbackTest.cpp MidiLoopbackTest.h
 	MidiLogPanel.cpp MidiLogPanel.h
 	OrmLookAndFeel.cpp OrmLookAndFeel.h
 	PatchButtonPanel.cpp PatchButtonPanel.h

--- a/The-Orm/MainComponent.cpp
+++ b/The-Orm/MainComponent.cpp
@@ -55,7 +55,7 @@ const std::string kExportPIF { "exportPIF" };
 const std::string kShowDiff{ "showDiff" };
 const std::string kCopyBankPatchNames{ "copyBankPatchNames" };
 const std::string kSynthDetection{ "synthDetection" };
-const std::string kLoopDetection{ "loopDetection" };
+const std::string kMidiTest{ "midiTest" };
 const std::string kFullMidiLog{ "fullMidiLog" };
 const std::string kSysexMidiLog{ "sysexMidiLog" };
 const std::string kSelectAdaptationDirect{ "selectAdaptationDir" };
@@ -270,7 +270,7 @@ MainComponent::MainComponent(bool makeYourOwnSize) :
 				{ "Merge multiple databases..."  },
 				{ "Quit" } } } },
 		{1, { "Edit", { { "Copy patch to clipboard..." }, { kCopyBankPatchNames}, { "Bulk rename patches..."},  {"Delete patches..."}, {"Reindex patches..."}}}},
-		{2, { "MIDI", { { "Auto-detect synths" }, { kSynthDetection},  { kRetrievePatches }, { kFetchEditBuffer }, { kReceiveManualDump }, { kLoopDetection}, { kFullMidiLog }, { kSysexMidiLog} }}},
+		{2, { "MIDI", { { "Auto-detect synths" }, { kSynthDetection},  { kRetrievePatches }, { kFetchEditBuffer }, { kReceiveManualDump }, { kMidiTest}, { kFullMidiLog }, { kSysexMidiLog} }}},
 		{3, { "Patches", { { kLoadSysEx}, { kExportSysEx }, { kExportBank},  { kExportPIF}, { kShowDiff} }}},
 		{4, { "Categories", { { "Edit categories" }, {{ "Show category naming rules file"}},  {"Edit category import mapping"},  {"Rerun auto categorize"}}}},
 		{5, { "View", { { "Open 2nd window" }, {"Scale 75%"}, {"Scale 100%"}, {"Scale 125%"}, {"Scale 150%"}, {"Scale 175%"}, {"Scale 200%"}}}},
@@ -321,8 +321,8 @@ MainComponent::MainComponent(bool makeYourOwnSize) :
 	{ "Quick check connectivity", { kSynthDetection, [this]() {
 		setupView_->quickConfigure();
 	}, juce::KeyPress::F2Key } },
-	{ "Check for MIDI loops", { kLoopDetection, [this]() {
-		setupView_->loopDetection();
+	{ "MIDI Test...", { kMidiTest, [this]() {
+		setupView_->midiTest();
 	} } },
 	{ "Log all MIDI messages", { kFullMidiLog, []() {
 		midikraft::MidiController::instance()->setMidiLogLevel(midikraft::MidiLogLevel::ALL_BUT_REALTIME);

--- a/The-Orm/MidiLoopbackTest.cpp
+++ b/The-Orm/MidiLoopbackTest.cpp
@@ -1,0 +1,253 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#include "MidiLoopbackTest.h"
+
+#include "MidiController.h"
+#include "MidiHelpers.h"
+
+#include <algorithm>
+
+namespace midikraft {
+
+	namespace {
+
+		struct TestCase {
+			std::string name;
+			MidiMessage message;
+		};
+
+		std::vector<juce::uint8> rawBytes(MidiMessage const& message)
+		{
+			return { message.getRawData(), message.getRawData() + message.getRawDataSize() };
+		}
+
+		MidiMessage makeTestSysex(size_t payloadSize, juce::uint8 testNumber)
+		{
+			// 0x7d is the MIDI manufacturer ID reserved for educational/development use.
+			std::vector<juce::uint8> payload(payloadSize);
+			payload[0] = 0x7d;
+			payload[1] = 'K';
+			payload[2] = 'K';
+			payload[3] = testNumber;
+
+			juce::uint32 randomState = 0x4b4b0000u + testNumber;
+			for (size_t index = 4; index < payload.size(); ++index) {
+				randomState = randomState * 1664525u + 1013904223u;
+				payload[index] = static_cast<juce::uint8>((randomState >> 16) & 0x7f);
+			}
+			return MidiHelpers::sysexMessage(payload);
+		}
+
+		std::vector<TestCase> createTestCases()
+		{
+			std::vector<TestCase> tests = {
+				{ "Note On", MidiMessage::noteOn(16, 60, static_cast<juce::uint8>(100)) },
+				{ "Note Off", MidiMessage::noteOff(16, 60, static_cast<juce::uint8>(64)) },
+				{ "Control Change", MidiMessage::controllerEvent(16, 119, 73) },
+				{ "Program Change", MidiMessage::programChange(16, 117) },
+				{ "Pitch Bend", MidiMessage::pitchWheel(16, 0x2345) },
+				{ "Polyphonic Aftertouch", MidiMessage::aftertouchChange(16, 60, 47) },
+				{ "Channel Pressure", MidiMessage::channelPressureChange(16, 53) }
+			};
+
+			const std::vector<size_t> sysexSizes = { 16, 128, 1024, 4096, 16384 };
+			juce::uint8 testNumber = 1;
+			for (auto size : sysexSizes) {
+				tests.push_back({ "SysEx payload " + std::to_string(size) + " bytes", makeTestSysex(size, testNumber++) });
+			}
+			return tests;
+		}
+
+		int timeoutFor(MidiMessage const& message)
+		{
+			// DIN MIDI transfers ten wire bits per byte at 31.25 kbit/s. Allow twice the
+			// theoretical transfer duration plus driver and scheduling headroom.
+			const int wireTimeMilliseconds = (message.getRawDataSize() * 10 * 1000 + 31249) / 31250;
+			return std::max(1000, wireTimeMilliseconds * 2 + 500);
+		}
+
+		bool isCandidate(MidiMessage const& expected, MidiMessage const& received)
+		{
+			if (expected.isSysEx()) return received.isSysEx();
+			if (received.isSysEx() || received.getRawDataSize() == 0) return false;
+			return received.getRawData()[0] == expected.getRawData()[0];
+		}
+
+		int firstDifference(std::vector<juce::uint8> const& expected, std::vector<juce::uint8> const& received)
+		{
+			const auto commonSize = std::min(expected.size(), received.size());
+			for (size_t index = 0; index < commonSize; ++index) {
+				if (expected[index] != received[index]) return static_cast<int>(index);
+			}
+			return expected.size() == received.size() ? -1 : static_cast<int>(commonSize);
+		}
+
+		struct CallbackState {
+			explicit CallbackState(juce::String inputIdentifier) : inputIdentifier(std::move(inputIdentifier)) {}
+
+			juce::String inputIdentifier;
+			CriticalSection lock;
+			WaitableEvent receivedEvent;
+			MidiMessage expected;
+			std::vector<juce::uint8> received;
+			std::vector<juce::uint8> partial;
+			bool waiting = false;
+		};
+
+		class LoopbackRunner {
+		public:
+			LoopbackRunner(juce::MidiDeviceInfo const& input, juce::MidiDeviceInfo const& output,
+				std::weak_ptr<ProgressHandler> progressHandler) :
+				input_(input), output_(output), progressHandler_(progressHandler),
+				callbackState_(std::make_shared<CallbackState>(input.identifier))
+			{
+			}
+
+			MidiLoopbackTestReport run()
+			{
+				MidiLoopbackTestReport report;
+				report.midiInput = input_;
+				report.midiOutput = output_;
+
+				auto controller = MidiController::instance();
+				if (!controller->enableMidiInput(input_)) {
+					report.error = "Could not open MIDI input " + input_.name.toStdString();
+					return report;
+				}
+
+				auto midiOutput = controller->getMidiOutput(output_);
+				if (!midiOutput->isValid()) {
+					report.error = "Could not open MIDI output " + output_.name.toStdString();
+					return report;
+				}
+
+				auto callbackState = callbackState_;
+				controller->addMessageHandler(handler_, [callbackState](MidiInput* source, MidiMessage const& message) {
+					if (source == nullptr || source->getDeviceInfo().identifier != callbackState->inputIdentifier) return;
+
+					const ScopedLock lock(callbackState->lock);
+					if (!callbackState->waiting || !isCandidate(callbackState->expected, message)) return;
+					callbackState->received = rawBytes(message);
+					callbackState->receivedEvent.signal();
+				});
+				controller->addPartialMessageHandler(handler_, [callbackState](MidiInput* source, const juce::uint8* data,
+					int numBytesSoFar, double timestamp) {
+					ignoreUnused(timestamp);
+					if (source == nullptr || source->getDeviceInfo().identifier != callbackState->inputIdentifier
+						|| data == nullptr || numBytesSoFar <= 0) return;
+
+					const ScopedLock lock(callbackState->lock);
+					if (!callbackState->waiting || !callbackState->expected.isSysEx()) return;
+					callbackState->partial.assign(data, data + numBytesSoFar);
+				});
+
+				const auto tests = createTestCases();
+				for (size_t index = 0; index < tests.size(); ++index) {
+					if (shouldAbort()) {
+						report.cancelled = true;
+						break;
+					}
+
+					if (auto progress = progressHandler_.lock()) {
+						progress->setMessage("Testing " + tests[index].name + "...");
+					}
+					report.results.push_back(runTest(tests[index], *midiOutput));
+					if (report.results.back().status == MidiLoopbackTestStatus::Cancelled) {
+						report.cancelled = true;
+						break;
+					}
+					if (auto progress = progressHandler_.lock()) {
+						progress->setProgressPercentage((index + 1.0) / tests.size());
+					}
+					Thread::sleep(20);
+				}
+
+				controller->removePartialMessageHandler(handler_);
+				controller->removeMessageHandler(handler_);
+				return report;
+			}
+
+		private:
+			MidiLoopbackTestResult runTest(TestCase const& test, SafeMidiOutput& midiOutput)
+			{
+				MidiLoopbackTestResult result;
+				result.name = test.name;
+				result.expected = rawBytes(test.message);
+
+				{
+					const ScopedLock lock(callbackState_->lock);
+					callbackState_->expected = test.message;
+					callbackState_->received.clear();
+					callbackState_->partial.clear();
+					callbackState_->waiting = true;
+					callbackState_->receivedEvent.reset();
+				}
+
+				const auto started = Time::getMillisecondCounter();
+				midiOutput.sendMessageNow(test.message);
+				const bool received = waitForMessage(timeoutFor(test.message));
+				result.elapsedMilliseconds = static_cast<int>(Time::getMillisecondCounter() - started);
+
+				{
+					const ScopedLock lock(callbackState_->lock);
+					callbackState_->waiting = false;
+					result.received = callbackState_->received.empty() ? callbackState_->partial : callbackState_->received;
+				}
+				if (!result.received.empty()) result.firstDifferentByte = firstDifference(result.expected, result.received);
+
+				if (shouldAbort()) {
+					result.status = MidiLoopbackTestStatus::Cancelled;
+				}
+				else if (!received) {
+					result.status = result.received.empty() ? MidiLoopbackTestStatus::TimedOut : MidiLoopbackTestStatus::Incomplete;
+				}
+				else {
+					result.status = result.firstDifferentByte == -1 ? MidiLoopbackTestStatus::Passed : MidiLoopbackTestStatus::Mismatch;
+				}
+				return result;
+			}
+
+			bool waitForMessage(int timeoutMilliseconds)
+			{
+				const auto started = Time::getMillisecondCounter();
+				while (static_cast<int>(Time::getMillisecondCounter() - started) < timeoutMilliseconds) {
+					if (callbackState_->receivedEvent.wait(50)) return true;
+					if (shouldAbort()) return false;
+				}
+				return false;
+			}
+
+			bool shouldAbort() const
+			{
+				if (auto progress = progressHandler_.lock()) return progress->shouldAbort();
+				return false;
+			}
+
+			juce::MidiDeviceInfo input_;
+			juce::MidiDeviceInfo output_;
+			std::weak_ptr<ProgressHandler> progressHandler_;
+			MidiController::HandlerHandle handler_ = MidiController::makeOneHandle();
+			std::shared_ptr<CallbackState> callbackState_;
+		};
+
+	}
+
+	bool MidiLoopbackTestReport::allPassed() const
+	{
+		return error.empty() && !cancelled && !results.empty()
+			&& std::all_of(results.begin(), results.end(), [](MidiLoopbackTestResult const& result) {
+				return result.status == MidiLoopbackTestStatus::Passed;
+			});
+	}
+
+	MidiLoopbackTestReport MidiLoopbackTest::run(juce::MidiDeviceInfo const& midiInput,
+		juce::MidiDeviceInfo const& midiOutput, std::weak_ptr<ProgressHandler> progressHandler)
+	{
+		return LoopbackRunner(midiInput, midiOutput, progressHandler).run();
+	}
+
+}

--- a/The-Orm/MidiLoopbackTest.h
+++ b/The-Orm/MidiLoopbackTest.h
@@ -1,0 +1,53 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#pragma once
+
+#include "JuceHeader.h"
+#include "ProgressHandler.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace midikraft {
+
+	enum class MidiLoopbackTestStatus {
+		Passed,
+		TimedOut,
+		Incomplete,
+		Mismatch,
+		Cancelled
+	};
+
+	struct MidiLoopbackTestResult {
+		std::string name;
+		MidiLoopbackTestStatus status = MidiLoopbackTestStatus::TimedOut;
+		std::vector<juce::uint8> expected;
+		std::vector<juce::uint8> received;
+		int elapsedMilliseconds = 0;
+		int firstDifferentByte = -1;
+	};
+
+	struct MidiLoopbackTestReport {
+		juce::MidiDeviceInfo midiOutput;
+		juce::MidiDeviceInfo midiInput;
+		std::vector<MidiLoopbackTestResult> results;
+		std::string error;
+		bool cancelled = false;
+
+		bool allPassed() const;
+	};
+
+	class MidiLoopbackTest {
+	public:
+		// Runs synchronously. Call this from a worker thread, not the JUCE message thread.
+		static MidiLoopbackTestReport run(juce::MidiDeviceInfo const& midiInput,
+			juce::MidiDeviceInfo const& midiOutput,
+			std::weak_ptr<ProgressHandler> progressHandler = {});
+	};
+
+}

--- a/The-Orm/SetupView.cpp
+++ b/The-Orm/SetupView.cpp
@@ -15,7 +15,7 @@
 #include "GenericAdaptation.h"
 #include "CreateNewAdaptationDialog.h"
 #include "AutoDetectProgressWindow.h"
-#include "LoopDetection.h"
+#include "MidiLoopbackTest.h"
 
 
 #include "UIModel.h"
@@ -267,33 +267,102 @@ void SetupView::createNewAdaptation()
 	knobkraft::CreateNewAdaptationDialog::showDialog(&synthSetup_);
 }
 
-class LoopDetectorWindow : public ProgressHandlerWindow, public std::enable_shared_from_this<LoopDetectorWindow> {
+class MidiTestProgressWindow : public ProgressHandlerWindow, public std::enable_shared_from_this<MidiTestProgressWindow> {
 public:
-	LoopDetectorWindow() : ProgressHandlerWindow("Checking for MIDI loops...", "Sending test messages to all MIDI outputs to detect if we have a loop in the configuration") {
+	MidiTestProgressWindow(juce::MidiDeviceInfo input, juce::MidiDeviceInfo output) :
+		ProgressHandlerWindow("Testing MIDI connection...", "Preparing MIDI loopback test..."),
+		input_(std::move(input)), output_(std::move(output)) {
 	}
 
 	virtual void run() override {
-		// Call the method that will block
-		loops = midikraft::LoopDetection::detectLoops(shared_from_this());
+		report = midikraft::MidiLoopbackTest::run(input_, output_, shared_from_this());
 	}
 
-	std::vector<midikraft::MidiLoop> loops;
+	midikraft::MidiLoopbackTestReport report;
+
+private:
+	juce::MidiDeviceInfo input_;
+	juce::MidiDeviceInfo output_;
 };
 
-void SetupView::loopDetection()
-{
-	std::shared_ptr<LoopDetectorWindow> modalWindow = std::make_shared<LoopDetectorWindow>();
-	modalWindow->runThread();
-	for (auto loop : modalWindow->loops) {
-		std::string typeName;
-		switch (loop.type) {
-		case midikraft::MidiLoopType::Note: typeName = "MIDI Note"; break;
-		case midikraft::MidiLoopType::Sysex: typeName = "Sysex"; break;
+namespace {
+
+	std::string statusName(midikraft::MidiLoopbackTestStatus status)
+	{
+		switch (status) {
+		case midikraft::MidiLoopbackTestStatus::Passed: return "PASS";
+		case midikraft::MidiLoopbackTestStatus::TimedOut: return "TIMEOUT";
+		case midikraft::MidiLoopbackTestStatus::Incomplete: return "INCOMPLETE";
+		case midikraft::MidiLoopbackTestStatus::Mismatch: return "MISMATCH";
+		case midikraft::MidiLoopbackTestStatus::Cancelled: return "CANCELLED";
 		}
-		spdlog::warn("Warning: {} loop detected. Sending sysex to {} is returned on {}", typeName, loop.midiOutput.name, loop.midiInput.name);
+		return "UNKNOWN";
 	}
-	if (modalWindow->loops.empty()) {
-		spdlog::info("All clear, no MIDI loops detected when sending to all available MIDI outputs");
+
+	juce::String resultText(midikraft::MidiLoopbackTestReport const& report)
+	{
+		if (!report.error.empty()) return report.error;
+
+		juce::String text;
+		text << "Output: " << report.midiOutput.name << "\n"
+			<< "Input: " << report.midiInput.name << "\n\n";
+		for (auto const& result : report.results) {
+			text << result.name << ": " << statusName(result.status)
+				<< " (" << result.received.size() << "/" << result.expected.size()
+				<< " bytes, " << result.elapsedMilliseconds << " ms)";
+			if (result.firstDifferentByte >= 0) {
+				text << ", first difference at offset " << result.firstDifferentByte;
+			}
+			text << "\n";
+		}
+		if (report.cancelled) text << "\nTest cancelled.";
+		return text;
+	}
+
+}
+
+void SetupView::midiTest()
+{
+	auto inputs = juce::MidiInput::getAvailableDevices();
+	auto outputs = juce::MidiOutput::getAvailableDevices();
+	if (inputs.isEmpty() || outputs.isEmpty()) {
+		juce::AlertWindow::showMessageBox(juce::AlertWindow::WarningIcon, "MIDI Test",
+			"At least one MIDI input and one MIDI output are required.");
+		return;
+	}
+
+	juce::StringArray inputNames;
+	for (auto const& input : inputs) inputNames.add(input.name);
+	juce::StringArray outputNames;
+	for (auto const& output : outputs) outputNames.add(output.name);
+
+	juce::AlertWindow selector("MIDI Test",
+		"Connect the selected MIDI output directly to the selected MIDI input with a cable. "
+		"The test sends channel messages and deterministic SysEx data up to 16 KiB, then compares what returns byte-for-byte.",
+		juce::AlertWindow::QuestionIcon);
+	selector.addComboBox("midiOutput", outputNames, "MIDI output");
+	selector.addComboBox("midiInput", inputNames, "MIDI input");
+	selector.getComboBoxComponent("midiOutput")->setSelectedItemIndex(0);
+	selector.getComboBoxComponent("midiInput")->setSelectedItemIndex(0);
+	selector.addButton("Run test", 1, juce::KeyPress(juce::KeyPress::returnKey));
+	selector.addButton("Cancel", 0, juce::KeyPress(juce::KeyPress::escapeKey));
+	if (selector.runModalLoop() != 1) return;
+
+	const auto outputIndex = selector.getComboBoxComponent("midiOutput")->getSelectedItemIndex();
+	const auto inputIndex = selector.getComboBoxComponent("midiInput")->getSelectedItemIndex();
+	if (!juce::isPositiveAndBelow(outputIndex, outputs.size()) || !juce::isPositiveAndBelow(inputIndex, inputs.size())) return;
+
+	auto progressWindow = std::make_shared<MidiTestProgressWindow>(inputs.getReference(inputIndex), outputs.getReference(outputIndex));
+	progressWindow->runThread();
+
+	const auto text = resultText(progressWindow->report);
+	if (progressWindow->report.allPassed()) {
+		spdlog::info("MIDI loopback test passed:\n{}", text.toStdString());
+		juce::AlertWindow::showMessageBox(juce::AlertWindow::InfoIcon, "MIDI Test passed", text);
+	}
+	else {
+		spdlog::warn("MIDI loopback test did not pass:\n{}", text.toStdString());
+		juce::AlertWindow::showMessageBox(juce::AlertWindow::WarningIcon, "MIDI Test results", text);
 	}
 }
 

--- a/The-Orm/SetupView.h
+++ b/The-Orm/SetupView.h
@@ -29,7 +29,7 @@ public:
 	virtual void resized() override;
 
 	void quickConfigure();
-	void loopDetection();
+	void midiTest();
 	void autoDetect();
 	void createNewAdaptation();
 


### PR DESCRIPTION
## Summary
- replace the old MIDI loop scan with a selectable MIDI Test dialog
- exercise channel voice messages and deterministic SysEx payloads from 16 bytes to 16 KiB through the real JUCE MIDI path
- report pass, timeout, incomplete transfer, mismatch, elapsed time, and the first differing byte offset
- use size-aware DIN MIDI timeouts and cancellation-safe callback state

Closes #554

## Verification
- configured a clean Windows/Ninja Debug build
- built and linked the KnobKraftOrm target successfully
- physical loopback hardware test still required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive **MIDI Test** to verify communication between selected MIDI input and output devices.
  * Tests common MIDI messages and SysEx data, reporting passes, mismatches, timeouts, incomplete messages, or cancellations.
  * Added progress updates and an option to copy test results.

* **Changes**
  * Replaced the previous “Check for MIDI loops” menu option with “MIDI Test…”.
  * Displays a warning when required MIDI devices are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->