### PR TITLE
Add preformatted patch views and use JUCE text diffs

### DIFF
--- a/.github/workflows/builds-macos.yml
+++ b/.github/workflows/builds-macos.yml
@@ -77,6 +77,14 @@ jobs:
         path: |
           build/KnobKraft_Orm-*.dmg
 
+    - name: Archive DMG diagnostics
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: DMG packaging logs
+        path: build/_CPack_Packages/**/*.log
+        if-no-files-found: ignore
+
     - name: Publish release
       uses: xresloader/upload-to-github-release@v1
       env:

--- a/.github/workflows/builds-windows.yml
+++ b/.github/workflows/builds-windows.yml
@@ -64,6 +64,9 @@ jobs:
           cmake --build Builds --config RelWithDebInfo --target patch_database_migration_test
           Builds\RelWithDebInfo\patch_database_migration_test.exe
 
+      - name: Run patch text doctest
+        run: Builds\RelWithDebInfo\patch_text_test.exe
+
       - name: Setup Sentry CLI
         uses: mathieu-bour/setup-sentry-cli@1.2.0
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/builds-windows.yml
+++ b/.github/workflows/builds-windows.yml
@@ -53,9 +53,11 @@ jobs:
       - name: Run Python tests first
         run: |
           pip install -r requirements.txt
-          python -m pytest tests/test_hdiutil_repeat.py -q
           cd adaptations
           python -m pytest --all . -q --no-header
+
+      - name: Test DMG cleanup retries
+        run: python -m pytest tests/test_hdiutil_repeat.py -q
 
       - name: CMake build
         run: cmake --build Builds --config RelWithDebInfo --parallel

--- a/.github/workflows/builds-windows.yml
+++ b/.github/workflows/builds-windows.yml
@@ -48,7 +48,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         shell: bash
         run: |
-          cmake -S . -B Builds -G "Visual Studio 17 2022" -A x64 -DCRASH_REPORTING=ON -DSENTRY_DSN=$SENTRY_DSN -DSPARKLE_UPDATES=ON -DBUILD_PATCH_DATABASE_TESTS=ON
+          cmake -S . -B Builds -G "Visual Studio 17 2022" -A x64 -DCRASH_REPORTING=ON -DSENTRY_DSN=$SENTRY_DSN -DSPARKLE_UPDATES=ON -DBUILD_UNIT_TESTS=ON
 
       - name: Run Python tests first
         run: |

--- a/.github/workflows/builds-windows.yml
+++ b/.github/workflows/builds-windows.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Run Python tests first
         run: |
           pip install -r requirements.txt
+          python -m pytest tests/test_hdiutil_repeat.py -q
           cd adaptations
           python -m pytest --all . -q --no-header
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 	path = juce-utils
 	url = https://github.com/christofmuc/juce-utils.git
 	branch = master
-[submodule "third_party/dtl"]
-	path = third_party/dtl
-	url = https://github.com/cubicdaiya/dtl.git
 [submodule "third_party/SQLiteCpp"]
 	path = third_party/SQLiteCpp
 	url = https://github.com/SRombauts/SQLiteCpp.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ python -m pytest --all . -q --no-header
 
 The focused command is an example; select every affected adaptation and its dedicated tests. Report passed, failed and skipped tests honestly, and investigate unexpected skips. Mock MIDI verifies protocol sequences, not physical device timing.
 
-For C++/database changes, initialize pinned submodules in the clean worktree (`git submodule update --init --recursive`), follow the platform workflow's CMake prerequisites, configure with `-DBUILD_PATCH_DATABASE_TESTS=ON`, build `patch_database_migration_test`, and run that executable. Do not assume `ctest` executes it: the current Windows workflow runs the binary directly. On Visual Studio builds it is normally under the selected configuration directory.
+For C++/database changes, initialize pinned submodules in the clean worktree (`git submodule update --init --recursive`), follow the platform workflow's CMake prerequisites, configure with `-DBUILD_UNIT_TESTS=ON`, build `patch_database_migration_test`, and run that executable. Do not assume `ctest` executes it: the current Windows workflow runs the binary directly. On Visual Studio builds it is normally under the selected configuration directory.
 
 For documentation-only changes, check the history/credit ledger, Markdown rendering, links and `git diff --check`; do not claim that this replaces the release candidate's build/test gate.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,7 +356,7 @@ add_subdirectory(pytschirp)
 # Main module
 add_subdirectory(The-Orm)
 
-option(BUILD_PATCH_DATABASE_TESTS "Build the PatchDatabase doctest binary" OFF)
+option(BUILD_PATCH_DATABASE_TESTS "Build the Orm C++ regression tests" OFF)
 if(BUILD_PATCH_DATABASE_TESTS)
 	add_executable(patch_database_migration_test
 		tests/patch_database_migration_test.cpp
@@ -383,10 +383,7 @@ if(BUILD_PATCH_DATABASE_TESTS)
 		knobkraft-generic-adaptation
 		midikraft-access-virus
 		SQLiteCpp)
-endif()
 
-option(BUILD_PATCH_TEXT_TESTS "Build patch text view and diff tests" OFF)
-if(BUILD_PATCH_TEXT_TESTS)
 	add_executable(patch_text_test
 		tests/patch_text_test.cpp
 		The-Orm/PatchDiff.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,8 +356,8 @@ add_subdirectory(pytschirp)
 # Main module
 add_subdirectory(The-Orm)
 
-option(BUILD_PATCH_DATABASE_TESTS "Build the Orm C++ regression tests" OFF)
-if(BUILD_PATCH_DATABASE_TESTS)
+option(BUILD_UNIT_TESTS "Build the Orm C++ regression tests" OFF)
+if(BUILD_UNIT_TESTS)
 	add_executable(patch_database_migration_test
 		tests/patch_database_migration_test.cpp
 		tests/bank_dump_capability_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,3 +384,17 @@ if(BUILD_PATCH_DATABASE_TESTS)
 		midikraft-access-virus
 		SQLiteCpp)
 endif()
+
+option(BUILD_PATCH_TEXT_TESTS "Build patch text view and diff tests" OFF)
+if(BUILD_PATCH_TEXT_TESTS)
+	add_executable(patch_text_test
+		tests/patch_text_test.cpp
+		The-Orm/PatchDiff.cpp
+		The-Orm/PatchTextBox.cpp)
+	target_include_directories(patch_text_test PRIVATE
+		${CMAKE_CURRENT_LIST_DIR}
+		${CMAKE_CURRENT_LIST_DIR}/third_party/doctest)
+	target_link_libraries(patch_text_test PRIVATE midikraft-database knobkraft-generic-adaptation)
+	enable_testing()
+	add_test(NAME patch_text_test COMMAND patch_text_test)
+endif()

--- a/The-Orm/CMakeLists.txt
+++ b/The-Orm/CMakeLists.txt
@@ -75,7 +75,7 @@ set(SOURCES
 	MidiLogPanel.cpp MidiLogPanel.h
 	OrmLookAndFeel.cpp OrmLookAndFeel.h
 	PatchButtonPanel.cpp PatchButtonPanel.h
-	PatchDiff.cpp PatchDiff.h
+	PatchDiff.cpp PatchDiff.h TextDiffRanges.h PatchTextViews.h
 	PatchHistoryPanel.cpp PatchHistoryPanel.h
 	PatchHolderButton.cpp PatchHolderButton.h
 	PatchListTree.cpp PatchListTree.h
@@ -140,7 +140,7 @@ if (SPARKLE_UPDATES AND WIN32)
   target_link_directories(KnobKraftOrm PRIVATE "${WINSPARKLE_LIBDIR}")
 endif()
 target_include_directories(KnobKraftOrm SYSTEM
-	PRIVATE "${CMAKE_CURRENT_LIST_DIR}/../third_party/dtl" "${CMAKE_CURRENT_BINARY_DIR}")
+	PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_compile_definitions(KnobKraftOrm PRIVATE JUCE_MODULE_AVAILABLE_gin_gui JUCE_MODULE_AVAILABLE_gin)
 get_target_property(gin_include_dirs gin INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(KnobKraftOrm SYSTEM PRIVATE ${gin_include_dirs})

--- a/The-Orm/PatchDiff.cpp
+++ b/The-Orm/PatchDiff.cpp
@@ -11,20 +11,11 @@
 #include "Patch.h"
 #include "Capability.h"
 
-#include "LayeredPatchCapability.h"
 #include "DetailedParametersCapability.h"
+#include "PatchTextBox.h"
+#include "TextDiffRanges.h"
 
 #include <algorithm>
-#include <fmt/format.h>
-// Turn off warning on unknown pragmas for VC++
-#pragma warning(push)
-#pragma warning(disable: 4068)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-conversion"
-#include "dtl/dtl.hpp"
-#pragma GCC diagnostic pop
-#pragma warning(pop)
-
 
 class DiffTokenizer : public CodeTokeniser {
 public:
@@ -113,26 +104,18 @@ PatchDiff::PatchDiff(midikraft::Synth *activeSynth, midikraft::PatchHolder const
 	addAndMakeVisible(*p1Editor_);
 	addAndMakeVisible(*p2Editor_);
 
-	// Build the toggle buttons for the diff mode
-	addAndMakeVisible(hexBased_);
-	hexBased_.setButtonText("Show hex values");
-	hexBased_.setClickingTogglesState(true);
-	hexBased_.setToggleState(true, dontSendNotification);
-	hexBased_.setRadioGroupId(3, dontSendNotification);
-	hexBased_.addListener(this);
-	showHexDiff_ = true;
-
-	// If there is detailed parameter information, also show the second option
+	// Built-in views and adaptation-provided views share one selector.
+	addAndMakeVisible(viewSelector_);
+	viewSelector_.addItem("Raw hex", 1);
 	auto parameterDetails = midikraft::Capability::hasCapability<midikraft::DetailedParametersCapability>(patch1.patch());
-	if (parameterDetails) {
-		addAndMakeVisible(textBased_);
-		textBased_.setButtonText("Show parameter values");
-		textBased_.setToggleState(true, dontSendNotification);
-		textBased_.setRadioGroupId(3, dontSendNotification);
-		textBased_.setClickingTogglesState(true);
-		textBased_.addListener(this);	
-		showHexDiff_ = false;
+	auto parameterDetails2 = midikraft::Capability::hasCapability<midikraft::DetailedParametersCapability>(patch2.patch());
+	if (parameterDetails && parameterDetails2) viewSelector_.addItem("Parameter values", 2);
+	customViews_ = patch_text::commonViews(patch_text::viewsFor(p1_), patch_text::viewsFor(p2_));
+	for (size_t i = 0; i < customViews_.size(); ++i) {
+		viewSelector_.addItem(String::fromUTF8(customViews_[i].name.c_str()), 3 + static_cast<int>(i));
 	}
+	viewSelector_.setSelectedId(parameterDetails && parameterDetails2 ? 2 : 1, dontSendNotification);
+	viewSelector_.onChange = [this]() { fillDocuments(); };
 
 	fillDocuments();
 
@@ -149,8 +132,7 @@ void PatchDiff::resized()
 	Rectangle<int> area(getLocalBounds());
 	closeButton_.setBounds(area.removeFromBottom(20).withSizeKeepingCentre(100, 20));
 	auto topRow = area.removeFromTop(20);
-	hexBased_.setBounds(topRow.removeFromLeft(100));
-	textBased_.setBounds(topRow.removeFromLeft(100));
+	viewSelector_.setBounds(topRow);
 	auto leftColumn = area.removeFromLeft(area.getWidth() / 2);
 	patch1Name_.setBounds(leftColumn.removeFromTop(30));
 	p1Editor_->setBounds(leftColumn);
@@ -167,27 +149,13 @@ void PatchDiff::buttonClicked(Button *button)
 	} 
 }
 
-void PatchDiff::buttonStateChanged(Button *button)
-{
-	if (button->getToggleState()) {
-		if (button == &hexBased_) {
-			showHexDiff_ = true;
-			fillDocuments();
-		}
-		else if (button == &textBased_) {
-			showHexDiff_ = false;
-			fillDocuments();
-		}
-	}
-}
-
 void PatchDiff::fillDocuments()
 {
 	patch1Name_.setText(p1_.name(), dontSendNotification);
 	patch2Name_.setText(p2_.name(), dontSendNotification);
 
 	String doc1, doc2;
-	if (showHexDiff_) {
+	if (viewSelector_.getSelectedId() == 1) {
 		doc1 = makeHexDocument(&p1_);
 		doc2 = makeHexDocument(&p2_);
 		std::vector<Range<int>> diffRanges = diffFromData(p1_.patch(), p2_.patch());
@@ -195,15 +163,21 @@ void PatchDiff::fillDocuments()
 		tokenizer2_->setRangeList(diffRanges);
 	}
 	else {
-		doc1 = makeTextDocument(&p1_);
-		doc2 = makeTextDocument(&p2_);
-		std::vector<Range<int>> diffRanges1 = diffFromText(doc1, doc2);
-		std::vector<Range<int>> diffRanges2 = diffFromText(doc2, doc1);
-		tokenizer1_->setRangeList(diffRanges1);
-		tokenizer2_->setRangeList(diffRanges2);
+		if (viewSelector_.getSelectedId() == 2) {
+			doc1 = PatchTextBox::makeTextDocument(std::make_shared<midikraft::PatchHolder>(p1_));
+			doc2 = PatchTextBox::makeTextDocument(std::make_shared<midikraft::PatchHolder>(p2_));
+		}
+		else {
+			auto const& view = customViews_.at(static_cast<size_t>(viewSelector_.getSelectedId() - 3));
+			doc1 = String::fromUTF8(view.left.c_str());
+			doc2 = String::fromUTF8(view.right.c_str());
+		}
+		auto ranges = patch_text::diffRanges(doc1, doc2);
+		tokenizer1_->setRangeList(ranges.left);
+		tokenizer2_->setRangeList(ranges.right);
 	}
 
-	// Setup view
+	// Keep supplied whitespace and line endings verbatim. applyChanges() normalizes them.
 	p1Document_->replaceAllContent(doc1);
 	p2Document_->replaceAllContent(doc2);
 }
@@ -240,34 +214,6 @@ String PatchDiff::makeHexDocument(midikraft::PatchHolder *patch)
 	return result;
 }
 
-String PatchDiff::makeTextDocument(midikraft::PatchHolder *patch) {
-	auto realPatch = std::dynamic_pointer_cast<midikraft::Patch>(patch->patch());
-	if (realPatch) {
-		return patchToTextRaw(realPatch, false);
-	}
-	else {
-		return "makeTextDocument not implemented yet";
-	}
-}
-
-std::vector<Range<int>> PatchDiff::diffFromText(String &doc1, String &doc2) {
-	dtl::Diff< char, std::string> difference(doc1.toStdString(), doc2.toStdString());
-	difference.compose();
-
-	// Diff calculation for highlighting
-	std::vector<Range<int>> diffRanges;
-
-	// Loop over edit script and create highlighting ranges
-	auto editScript = difference.getSes();
-	for (auto edit : editScript.getSequence()) {
-	if (edit.second.type == dtl::SES_DELETE) {
-			diffRanges.push_back(Range<int>((int) (edit.second.beforeIdx - 1), (int) edit.second.beforeIdx));
-		}
-	}
-
-	return diffRanges;
-}
-
 std::vector<Range<int>> PatchDiff::diffFromData(std::shared_ptr<midikraft::DataFile> patch1, std::shared_ptr<midikraft::DataFile> patch2) {
 	// Diff calculation for highlighting
 	std::vector<Range<int>> diffRanges;
@@ -298,41 +244,5 @@ std::vector<Range<int>> PatchDiff::diffFromData(std::shared_ptr<midikraft::DataF
 		diffRanges.push_back(Range<int>(diffstart, positionInHexDocument((int) doc1.size())));
 	}
 	return diffRanges;
-}
-
-std::string PatchDiff::patchToTextRaw(std::shared_ptr<midikraft::Patch> patch, bool onlyActive)
-{
-	std::string result;
-
-	int numLayers = 1;
-	auto layers = midikraft::Capability::hasCapability<midikraft::LayeredPatchCapability>(patch);
-	if (layers) {
-		numLayers = layers->numberOfLayers();
-	}
-
-	auto parameterDetails = midikraft::Capability::hasCapability<midikraft::DetailedParametersCapability>(patch);
-
-	if (parameterDetails) {
-		for (int layer = 0; layer < numLayers; layer++) {
-			if (layers) {
-				if (layer > 0) result += "\n";
-				result = result + fmt::format("Layer: {}\n", layers->layerName(layer));
-			}
-			for (auto param : parameterDetails->allParameterDefinitions()) {
-				if (layers) {
-					auto multiLayerParam = midikraft::Capability::hasCapability<midikraft::SynthMultiLayerParameterCapability>(param);
-					jassert(multiLayerParam);
-					if (multiLayerParam) {
-						multiLayerParam->setSourceLayer(layer);
-					}
-				}
-				auto activeCheck = midikraft::Capability::hasCapability<midikraft::SynthParameterActiveDetectionCapability>(param);
-				if (!onlyActive || !activeCheck || !(activeCheck->isActive(patch.get()))) {
-					result = result + fmt::format("{}: {}\n", param->description(), param->valueInPatchToText(*patch));
-				}
-			}
-		}
-	}
-	return result;
 }
 

--- a/The-Orm/PatchDiff.h
+++ b/The-Orm/PatchDiff.h
@@ -10,6 +10,7 @@
 
 #include "Synth.h"
 #include "PatchHolder.h"
+#include "PatchTextViews.h"
 
 class DiffTokenizer;
 class CoupledScrollCodeEditor;
@@ -21,16 +22,12 @@ public:
 
 	void resized() override;
 	void buttonClicked(Button*) override;
-	void buttonStateChanged(Button*) override;
 
 private:
 	void fillDocuments();
 	static int positionInHexDocument(int positionInBinary);
 	String makeHexDocument(midikraft::PatchHolder *patch);
-	String makeTextDocument(midikraft::PatchHolder *patch);
-	std::vector<Range<int>> diffFromText(String &doc1, String &doc2);
 	std::vector<Range<int>> diffFromData(std::shared_ptr<midikraft::DataFile> patch1, std::shared_ptr<midikraft::DataFile> patch2);
-	std::string patchToTextRaw(std::shared_ptr<midikraft::Patch> patch, bool onlyActive);
 
 	midikraft::Synth *activeSynth_;
 	midikraft::PatchHolder p1_, p2_;
@@ -43,9 +40,8 @@ private:
 	std::unique_ptr <CoupledScrollCodeEditor> p1Editor_;
 	std::unique_ptr <CoupledScrollCodeEditor> p2Editor_;
 	TextButton closeButton_;
-	TextButton hexBased_, textBased_;
-
-	bool showHexDiff_;
+	ComboBox viewSelector_;
+	std::vector<patch_text::ComparisonView> customViews_;
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PatchDiff)
 };

--- a/The-Orm/PatchTextBox.cpp
+++ b/The-Orm/PatchTextBox.cpp
@@ -9,86 +9,72 @@
 #include "Capability.h"
 #include "DetailedParametersCapability.h"
 #include "LayeredPatchCapability.h"
+#include "PatchTextViews.h"
 
 #include <fmt/format.h>
 
-PatchTextBox::PatchTextBox(std::function<void()> forceResize, bool showParams /* = true */) : forceResize_(forceResize), showParams_(showParams), mode_(showParams ? DisplayMode::PARAMS : DisplayMode::HEX)
+PatchTextBox::PatchTextBox(std::function<void()> forceResize, bool showParams /* = true */) : forceResize_(forceResize), showParams_(showParams)
 {
 	document_ = std::make_unique<CodeDocument>();
 	textBox_ = std::make_unique<CodeEditorComponent>(*document_, nullptr);
 	textBox_->setScrollbarThickness(10);
-
 	textBox_->setReadOnly(true);
 	textBox_->setLineNumbersShown(false);
 	addChildComponent(*textBox_);
+	textBox_->setVisible(showParams_);
 
-	addAndMakeVisible(hexBased_);
-	hexBased_.setButtonText(showParams_ ? "Show hex values" : "Hex Dump");
+	addChildComponent(hexBased_);
+	hexBased_.setVisible(!showParams_);
+	hexBased_.setButtonText("Hex Dump");
 	hexBased_.setClickingTogglesState(true);
-	
-	if (showParams_) {
-		textBox_->setVisible(true);
-		hexBased_.setRadioGroupId(3, dontSendNotification);
-		hexBased_.onClick = [this]() {
-			mode_ = DisplayMode::HEX;
-			refreshText();
-		};
+	hexBased_.onClick = [this]() {
+		textBox_->setVisible(hexBased_.getToggleState());
+		viewSelector_.setVisible(hexBased_.getToggleState() && viewSelector_.getNumItems() > 1);
+		if (forceResize_) forceResize_();
+	};
 
-		addAndMakeVisible(textBased_);
-		textBased_.setButtonText("Show parameter values");
-		textBased_.setToggleState(true, dontSendNotification);
-		textBased_.setRadioGroupId(3, dontSendNotification);
-		textBased_.setClickingTogglesState(true);
-		textBased_.setVisible(false);
-		textBased_.onClick = [this]() {
-			mode_ = DisplayMode::PARAMS;
-			refreshText();
-		};
-
-		hexBased_.setToggleState(true, dontSendNotification);
-	}
-	else {
-		hexBased_.setToggleState(false, dontSendNotification);
-		hexBased_.onClick = [this]() {
-			textBox_->setVisible(hexBased_.getToggleState());
-			if (forceResize_) {
-				forceResize_();
-			}
-		};
-	}
+	addChildComponent(viewSelector_);
+	viewSelector_.setVisible(showParams_);
+	viewSelector_.addItem("Raw hex", 1);
+	viewSelector_.setSelectedId(1, dontSendNotification);
+	viewSelector_.onChange = [this]() {
+		refreshText();
+		if (forceResize_) forceResize_();
+	};
 }
 
 void PatchTextBox::fillTextBox(std::shared_ptr<midikraft::PatchHolder> patch)
 {
+	auto previousId = viewSelector_.getSelectedId();
+	std::string previousName;
+	if (previousId >= 3) previousName = customViews_.at(static_cast<size_t>(previousId - 3)).first;
+	bool firstPatch = !patch_;
 	patch_ = patch;
-
-	if (patch) {
-		// If there is detailed parameter information, also show the second option
-		if (showParams_) {
-			auto parameterDetails = midikraft::Capability::hasCapability<midikraft::DetailedParametersCapability>(patch->patch());
-			if (parameterDetails) {
-				textBased_.setVisible(true);
-			}
-			else {
-				mode_ = DisplayMode::HEX;
-				textBased_.setVisible(false);
-				hexBased_.setToggleState(true, dontSendNotification);
-			}
-		}
-		refreshText();
+	customViews_ = patch ? patch_text::viewsFor(*patch) : midikraft::PatchTextViews{};
+	viewSelector_.clear(dontSendNotification);
+	viewSelector_.addItem("Raw hex", 1);
+	bool hasParams = patch && midikraft::Capability::hasCapability<midikraft::DetailedParametersCapability>(patch->patch());
+	if (hasParams) viewSelector_.addItem("Parameter values", 2);
+	int selectedId = hasParams && (previousId == 2 || (firstPatch && showParams_)) ? 2 : 1;
+	for (size_t i = 0; i < customViews_.size(); ++i) {
+		auto id = 3 + static_cast<int>(i);
+		viewSelector_.addItem(String::fromUTF8(customViews_[i].first.c_str()), id);
+		if (previousId >= 3 && customViews_[i].first == previousName) selectedId = id;
 	}
+	viewSelector_.setSelectedId(selectedId, dontSendNotification);
+	viewSelector_.setVisible(showParams_ || (hexBased_.getToggleState() && viewSelector_.getNumItems() > 1));
+	hexBased_.setButtonText(viewSelector_.getNumItems() > 1 ? "Patch text" : "Hex Dump");
+	refreshText();
+	if (forceResize_) forceResize_();
 }
 
 void PatchTextBox::refreshText() {
 	String text;
-	switch (mode_) {
-	case DisplayMode::HEX:
-		text = makeHexDocument(patch_);
-		break;
-	case DisplayMode::PARAMS:
-		text = makeTextDocument(patch_);
-		break;
-	}
+	auto selectedId = viewSelector_.getSelectedId();
+	if (selectedId == 1) text = makeHexDocument(patch_);
+	else if (selectedId == 2) text = makeTextDocument(patch_);
+	else text = String::fromUTF8(customViews_.at(static_cast<size_t>(selectedId - 3)).second.c_str());
+	// No reflow, trimming, or newline normalization of adaptation-provided text.
 	document_->replaceAllContent(text);
 }
 
@@ -97,12 +83,12 @@ void PatchTextBox::resized()
 	auto area = getLocalBounds();
 
 	auto topRow = area.removeFromTop(20);
-	hexBased_.setBounds(topRow.removeFromLeft(100));
-	textBased_.setBounds(topRow.removeFromLeft(100));
+	if (!showParams_) hexBased_.setBounds(topRow.removeFromLeft(100));
+	viewSelector_.setBounds(topRow);
 
 	textBox_->setBounds(area);
 
-	if (lastLayoutedWidth_.has_value() && *lastLayoutedWidth_ != area.getWidth() && patch_) {
+	if (viewSelector_.getSelectedId() == 1 && lastLayoutedWidth_.has_value() && *lastLayoutedWidth_ != area.getWidth() && patch_) {
 		refreshText();
 	}
 }

--- a/The-Orm/PatchTextBox.h
+++ b/The-Orm/PatchTextBox.h
@@ -9,12 +9,10 @@
 #include "JuceHeader.h"
 
 #include "PatchHolder.h"
+#include "PatchTextCapability.h"
 
 class PatchTextBox : public Component {
 public:
-	enum class DisplayMode {
-		HEX, PARAMS
-	};
 	PatchTextBox(std::function<void()> forceResize = {}, bool showParams = true);
 
 	void fillTextBox(std::shared_ptr<midikraft::PatchHolder> patch);
@@ -35,8 +33,9 @@ private:
 	std::shared_ptr<midikraft::PatchHolder> patch_;
 	std::unique_ptr<CodeDocument> document_;
 	std::unique_ptr<CodeEditorComponent> textBox_;
-	TextButton hexBased_, textBased_;
-	DisplayMode mode_;
+	TextButton hexBased_;
+	ComboBox viewSelector_;
+	midikraft::PatchTextViews customViews_;
 	std::optional<int> lastLayoutedWidth_;
 };
 

--- a/The-Orm/PatchTextViews.h
+++ b/The-Orm/PatchTextViews.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Capability.h"
+#include "PatchHolder.h"
+#include "PatchTextCapability.h"
+
+namespace patch_text {
+
+	inline midikraft::PatchTextViews viewsFor(midikraft::PatchHolder const& patch) {
+		auto capability = midikraft::Capability::hasCapability<midikraft::PatchTextCapability>(patch.synth());
+		return capability && patch.patch() ? capability->getClearText(*patch.patch()) : midikraft::PatchTextViews{};
+	}
+
+	struct ComparisonView {
+		std::string name, left, right;
+	};
+
+	inline std::vector<ComparisonView> commonViews(midikraft::PatchTextViews const& left, midikraft::PatchTextViews const& right) {
+		std::vector<ComparisonView> result;
+		for (auto const& l : left) {
+			for (auto const& r : right) {
+				if (l.first == r.first) {
+					result.push_back({l.first, l.second, r.second});
+					break;
+				}
+			}
+		}
+		return result;
+	}
+
+}

--- a/The-Orm/TextDiffRanges.h
+++ b/The-Orm/TextDiffRanges.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+#include <vector>
+
+namespace patch_text {
+
+	struct DiffRanges {
+		std::vector<juce::Range<int>> left, right;
+	};
+
+	inline std::vector<juce::String> linesWithEndings(juce::String const& text) {
+		std::vector<juce::String> lines;
+		auto cursor = text.getCharPointer();
+		while (!cursor.isEmpty()) {
+			auto start = cursor;
+			while (!cursor.isEmpty()) {
+				auto c = cursor.getAndAdvance();
+				if (c == '\n') break;
+				if (c == '\r') {
+					if (*cursor == '\n') ++cursor;
+					break;
+				}
+			}
+			lines.emplace_back(start, cursor);
+		}
+		return lines;
+	}
+
+	inline DiffRanges diffRanges(juce::String const& left, juce::String const& right) {
+		DiffRanges result;
+		auto append = [&](juce::String const& a, juce::String const& b, int leftStart, int rightStart) {
+			int offset = 0;
+			// TextDiff positions address the progressively edited string. Translate
+			// deletions back to the original; insertions already address the target.
+			juce::TextDiff difference(a, b);
+			for (auto const& change : difference.changes) {
+				if (change.isDeletion()) {
+					auto start = leftStart + change.start - offset;
+					result.left.emplace_back(start, start + change.length);
+					offset -= change.length;
+				}
+				else {
+					auto length = change.insertedText.length();
+					result.right.emplace_back(rightStart + change.start, rightStart + change.start + length);
+					offset += length;
+				}
+			}
+		};
+
+		auto leftLines = linesWithEndings(left);
+		auto rightLines = linesWithEndings(right);
+		if (leftLines.size() == rightLines.size()) {
+			// Stable rows are usual for patch dumps. Diff them individually to avoid
+			// TextDiff's coarse fallback on long texts with distant small changes.
+			int leftStart = 0, rightStart = 0;
+			for (size_t i = 0; i < leftLines.size(); ++i) {
+				append(leftLines[i], rightLines[i], leftStart, rightStart);
+				leftStart += leftLines[i].length();
+				rightStart += rightLines[i].length();
+			}
+		}
+		else {
+			// Let JUCE find insertions/deletions when the number of rows changes.
+			append(left, right, 0, 0);
+		}
+		return result;
+	}
+
+}

--- a/The-Orm/hdiutil_repeat.sh
+++ b/The-Orm/hdiutil_repeat.sh
@@ -34,12 +34,15 @@ if [ "$cmd" = "detach" ]; then
     exit 0
   fi
 
-  # Last-resort fallback for stale/busy mounts.
-  if [ -n "${2:-}" ]; then
-    hdiutil "$@" -force
+  # XProtect/Spotlight can also briefly hold the mount during forced detach.
+  # Keep retrying the same temporary image; never detach unrelated volumes.
+  if [ -n "${2:-}" ] && retry_hdiutil 10 "$@" -force; then
     exit 0
   fi
 
+  # CPack otherwise hides hdiutil's output in its private log directory.
+  echo "Failed to detach temporary image after normal and forced retries: ${2:-}" >&2
+  hdiutil info >&2 || true
   exit 1
 fi
 

--- a/adaptations/Adaptation Programming Guide.md
+++ b/adaptations/Adaptation Programming Guide.md
@@ -1,3 +1,40 @@
 # Adaptation Programming Guide
 
 Continue to the maintained [Adaptation Programming Guide](../docs/programming-guide.md).
+
+## Additional patch text views
+
+The optional `getClearText(message)` callback returns a list of `(name, text)` string
+pairs. The input is the complete stored patch data, in the same format as
+`nameFromDump`, including SysEx framing and any concatenated messages. The adaptation
+is responsible for extracting and decoding the payload.
+
+```python
+def getClearText(message):
+    if not isEditBufferDump(message):
+        return []
+    data = unescapeSysex(message[5:-1])  # Use your synth's framing here.
+    text = "\n".join(
+        f"{offset:04x} " + " ".join(f"{b:02x}" for b in data[offset:offset + 8])
+        for offset in range(0, len(data), 8)
+    )
+    return [("Unescaped patch data", text)]
+```
+
+Views appear in the patch comparison and current-patch sidebar selectors. Each
+name must be nonempty, unique within the result, and stable across patches.
+Comparison offers names present on both sides and matches them by name, independent
+of return order. Return `[]` for unsupported patch types or when no views apply.
+Omitting the callback preserves the built-in views; a callback error is logged and
+also falls back to those views.
+
+Text is displayed verbatim in a fixed-width, non-wrapping editor: spaces, tabs,
+blank lines, line endings, and trailing newlines are preserved. Resizing does not
+reformat it. Use consistent line ordering and widths for comparable patches. The
+comparison highlights text changes without inserting alignment lines or changing
+your layout. When both texts have the same number of rows, corresponding rows are
+compared independently to keep small changes in long dumps localized. When row
+counts differ, JUCE compares the complete texts. Additional representations can
+show decimal bytes, parameter values,
+layers, or synth-specific offset reports. No generic mapping between packed and
+unpacked byte indices is inferred.

--- a/adaptations/GenericAdaptation.cpp
+++ b/adaptations/GenericAdaptation.cpp
@@ -32,6 +32,7 @@
 #pragma warning ( pop )
 #endif
 #include <memory>
+#include <set>
 #include <spdlog/spdlog.h>
 #include "SpdLogJuce.h"
 
@@ -83,6 +84,7 @@ namespace knobkraft {
 		* kFriendlyBankName = "friendlyBankName",
 		* kFriendlyProgramName = "friendlyProgramName",
 		* kSetupHelp = "setupHelp",
+		* kGetClearText = "getClearText",
 		* kGetStoredTags = "storedTags",
 		* kIndicateBankDownloadMethod= "bankDownloadMethodOverride",
 		* kMessageTimings = "messageTimings",
@@ -127,6 +129,7 @@ namespace knobkraft {
 		kFriendlyBankName,
 		kFriendlyProgramName,
 		kSetupHelp,
+		kGetClearText,
 		kGetStoredTags,
 		kMessageTimings,
 		kExpectsUploadReply,
@@ -687,6 +690,30 @@ namespace knobkraft {
 			logAdaptationError(kSetupHelp, ex);
 			return Synth::setupHelpText();
 		}
+	}
+
+	midikraft::PatchTextViews GenericAdaptation::getClearText(midikraft::DataFile const& patch) const
+	{
+		py::gil_scoped_acquire acquire;
+		if (!pythonModuleHasFunction(kGetClearText)) return {};
+		try {
+			// Pass a copy, just like the other patch callbacks. Never change stored data.
+			std::vector<int> data(patch.data().begin(), patch.data().end());
+			auto views = py::cast<midikraft::PatchTextViews>(callMethod(kGetClearText, data));
+			std::set<std::string> names;
+			for (auto const& view : views) {
+				if (view.first.empty() || !names.insert(view.first).second) {
+					throw std::runtime_error("getClearText view names must be nonempty and unique");
+				}
+			}
+			return views;
+		}
+		catch (std::exception& ex) {
+			// In particular, consume Python errors here so a faulty optional view
+			// cannot prevent the raw view or subsequent adaptation calls from working.
+			logAdaptationError(kGetClearText, ex);
+		}
+		return {};
 	}
 
 	int GenericAdaptation::defaultReplyTimeoutMs() const

--- a/adaptations/GenericAdaptation.h
+++ b/adaptations/GenericAdaptation.h
@@ -17,6 +17,7 @@
 #include "LegacyLoaderCapability.h"
 #include "CustomProgramChangeCapability.h"
 #include "UploadHandshakeCapability.h"
+#include "PatchTextCapability.h"
 
 #ifdef _MSC_VER
 #pragma warning ( push )
@@ -77,6 +78,7 @@ namespace knobkraft {
 		public midikraft::RuntimeCapability<midikraft::CustomProgramChangeCapability>,
 		public midikraft::RuntimeCapability<midikraft::UploadHandshakeCapability>,
 		public midikraft::BankDownloadMethodIndicationCapability,
+		public midikraft::PatchTextCapability,
 		public std::enable_shared_from_this<GenericAdaptation>
 	{
 	public:
@@ -109,6 +111,7 @@ namespace knobkraft {
 		virtual void sendBlockOfMessagesToSynth(juce::MidiDeviceInfo const &midiOutput, std::vector<MidiMessage> const& buffer) override;
 		virtual std::string friendlyProgramName(MidiProgramNumber programNo) const override;  //TODO this looks like a capability
 		virtual std::string setupHelpText() const override;
+		midikraft::PatchTextViews getClearText(midikraft::DataFile const& patch) const override;
 
 		// Internal workings of the Generic Adaptation module
 		bool pythonModuleHasFunction(std::string const &functionName) const;

--- a/adaptations/KorgMS2000.py
+++ b/adaptations/KorgMS2000.py
@@ -119,6 +119,17 @@ def numberOfPatchesPerBank():
     return 16
 
 
+def getClearText(message):
+    if not isEditBufferDump(message):
+        return []
+    data = unescapeSysex(message[5:-1])
+    text = "\n".join(
+        f"{offset:04x} " + " ".join(f"{byte:02x}" for byte in data[offset:offset + 8])
+        for offset in range(0, len(data), 8)
+    )
+    return [("Unescaped patch data", text)]
+
+
 def nameFromDump(message):
     if isEditBufferDump(message):
         # We need to first convert from 7 bit data to 8 bit data, before we can extract the program name

--- a/adaptations/test_KorgMS2000.py
+++ b/adaptations/test_KorgMS2000.py
@@ -6,3 +6,14 @@ def testEscaping():
     escaped = KorgMS2000.escapeSysex(testData)
     back = KorgMS2000.unescapeSysex(escaped)
     assert testData == back
+
+
+def test_clear_text_uses_unpacked_payload_offsets():
+    payload = [0x80, 0x01, 0xff, 0x7f, 0, 0x42, 0xa5, 0x11, 0x22]
+    message = [0xf0, 0x42, 0x30, 0x58, 0x40] + KorgMS2000.escapeSysex(payload) + [0xf7]
+    original = message.copy()
+    assert KorgMS2000.getClearText(message) == [
+        ("Unescaped patch data", "0000 80 01 ff 7f 00 42 a5 11\n0008 22")
+    ]
+    assert message == original
+    assert KorgMS2000.getClearText([]) == []

--- a/docker/archlinux/Dockerfile
+++ b/docker/archlinux/Dockerfile
@@ -30,7 +30,7 @@ RUN git config --global --add safe.directory /KnobKraft-orm \
     && git submodule update --recursive --init --depth 1
 
 RUN cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=off \
-    -DBUILD_PATCH_DATABASE_TESTS=ON \
+    -DBUILD_UNIT_TESTS=ON \
     -S . \
     -B builds
 

--- a/docs/programming-guide.md
+++ b/docs/programming-guide.md
@@ -960,3 +960,40 @@ https://github.com/christofmuc/KnobKraft-orm/blob/master/adaptations/implementat
 
 
 The adaptations that are shipped with the KnobKraft Orm are stored in the adaptations subdirectory of the program directory. Check them out there as well.
+
+## Additional patch text views
+
+The optional `getClearText(message)` callback returns a list of `(name, text)` string
+pairs. The input is the complete stored patch data, in the same format as
+`nameFromDump`, including SysEx framing and any concatenated messages. The adaptation
+is responsible for extracting and decoding the payload.
+
+```python
+def getClearText(message):
+    if not isEditBufferDump(message):
+        return []
+    data = unescapeSysex(message[5:-1])  # Use your synth's framing here.
+    text = "\n".join(
+        f"{offset:04x} " + " ".join(f"{b:02x}" for b in data[offset:offset + 8])
+        for offset in range(0, len(data), 8)
+    )
+    return [("Unescaped patch data", text)]
+```
+
+Views appear in the patch comparison and current-patch sidebar selectors. Each
+name must be nonempty, unique within the result, and stable across patches.
+Comparison offers names present on both sides and matches them by name, independent
+of return order. Return `[]` for unsupported patch types or when no views apply.
+Omitting the callback preserves the built-in views; a callback error is logged and
+also falls back to those views.
+
+Text is displayed verbatim in a fixed-width, non-wrapping editor: spaces, tabs,
+blank lines, line endings, and trailing newlines are preserved. Resizing does not
+reformat it. Use consistent line ordering and widths for comparable patches. The
+comparison highlights text changes without inserting alignment lines or changing
+your layout. When both texts have the same number of rows, corresponding rows are
+compared independently to keep small changes in long dumps localized. When row
+counts differ, JUCE compares the complete texts. Additional representations can
+show decimal bytes, parameter values,
+layers, or synth-specific offset reports. No generic mapping between packed and
+unpacked byte indices is inferred.

--- a/tests/patch_text_test.cpp
+++ b/tests/patch_text_test.cpp
@@ -1,0 +1,168 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest/doctest.h"
+
+#include "The-Orm/TextDiffRanges.h"
+#include "The-Orm/PatchTextViews.h"
+#include "The-Orm/PatchDiff.h"
+#include "The-Orm/PatchTextBox.h"
+#include "GenericAdaptation.h"
+#include "test_helpers.h"
+
+namespace {
+
+juce::String withoutRanges(juce::String text, std::vector<juce::Range<int>> const& ranges) {
+	int end = text.length();
+	for (auto it = ranges.rbegin(); it != ranges.rend(); ++it) {
+		CHECK(it->getStart() >= 0);
+		CHECK(it->getEnd() <= end);
+		end = it->getStart();
+		text = text.replaceSection(it->getStart(), it->getLength(), {});
+	}
+	return text;
+}
+
+template<class T> std::vector<T*> children(juce::Component& component) {
+	std::vector<T*> result;
+	for (auto child : component.getChildren()) {
+		if (auto match = dynamic_cast<T*>(child)) result.push_back(match);
+	}
+	return result;
+}
+
+class TextSynth : public test_helpers::DummySynth, public midikraft::PatchTextCapability {
+public:
+	TextSynth() : DummySynth("Text synth") {}
+	midikraft::PatchTextViews getClearText(midikraft::DataFile const& patch) const override {
+		if (patch.data().empty()) return {};
+		return {{"Decoded", "  Head\r\n\r\n\tValue: " + std::to_string(patch.at(0)) + "  \n"}};
+	}
+};
+
+}
+
+TEST_CASE("text diffs use original character coordinates on both sides") {
+	std::vector<std::pair<juce::String, juce::String>> cases = {
+		{"", ""}, {"same\n", "same\n"}, {"", "new\n"}, {"old\n", ""},
+		{"prefix VALUE suffix", "prefix NEW suffix"},
+		{"abc common DELETE suffix", "INSERT abc common suffix"},
+		{"one\n\nthree\n", "one\nTWO\n\nthree\n"},
+		{"  one\r\n\tthree  \r\n", "  two\r\n\tthree  \r\n"},
+		{juce::String::fromUTF8("\xc3\xa4\xf0\x9f\x8e\xb9 prefix OLD suffix"),
+		 juce::String::fromUTF8("\xc3\xa4\xf0\x9f\x8e\xb9 prefix NEW suffix")}
+	};
+	for (auto const& texts : cases) {
+		auto ranges = patch_text::diffRanges(texts.first, texts.second);
+		CHECK(withoutRanges(texts.first, ranges.left) == withoutRanges(texts.second, ranges.right));
+		if (texts.first == texts.second) {
+			CHECK(ranges.left.empty());
+			CHECK(ranges.right.empty());
+		}
+		else CHECK_FALSE((ranges.left.empty() && ranges.right.empty()));
+	}
+	auto ranges = patch_text::diffRanges("abc common DELETE suffix", "INSERT abc common suffix");
+	REQUIRE(ranges.left.size() == 1);
+	CHECK(ranges.left[0] == juce::Range<int>(11, 18));
+	REQUIRE(ranges.right.size() == 1);
+	CHECK(ranges.right[0] == juce::Range<int>(0, 7));
+}
+
+TEST_CASE("long dumps retain localized highlighting for distant byte changes") {
+	juce::String left;
+	for (int row = 0; row < 256; ++row) left += "0000 00 00 00 00 00 00 00 00\n";
+	auto right = left.replaceSection(5, 2, "01").replaceSection(6008, 2, "02");
+	auto ranges = patch_text::diffRanges(left, right);
+	int highlighted = 0;
+	for (auto const& range : ranges.left) highlighted += range.getLength();
+	CHECK(highlighted <= 8);
+	CHECK(withoutRanges(left, ranges.left) == withoutRanges(right, ranges.right));
+}
+
+TEST_CASE("view matching uses names and preserves both texts") {
+	auto views = patch_text::commonViews({{"A", "left\r\n\r\n"}, {"B", " b "}, {"C", "c"}},
+		{{"B", "\tright\n"}, {"A", "a\r\n"}, {"D", "d"}});
+	REQUIRE(views.size() == 2);
+	CHECK(views[0].name == "A");
+	CHECK(views[0].left == "left\r\n\r\n");
+	CHECK(views[0].right == "a\r\n");
+	CHECK(views[1].name == "B");
+	CHECK(views[1].right == "\tright\n");
+}
+
+TEST_CASE("Python patch text callback is optional and failures do not poison later calls") {
+	struct Runtime {
+		Runtime() { knobkraft::GenericAdaptation::startupGenericAdaptation(); }
+		~Runtime() { knobkraft::GenericAdaptation::shutdownGenericAdaptation(); }
+	} runtime;
+	midikraft::DataFile patch(0, {0xf0, 0x42, 0x01, 0xf7});
+	auto run = [&](std::string code) {
+		return knobkraft::GenericAdaptation::fromBinaryCode("patch_text_fixture", "def name(): return 'Text fixture'\n" + code);
+	};
+	{
+		auto adaptation = run("");
+		REQUIRE(adaptation);
+		CHECK(adaptation->getClearText(patch).empty());
+	}
+	{
+		auto adaptation = run("def getClearText(message):\n"
+			"    assert message == [240, 66, 1, 247]\n"
+			"    message[0] = 0\n"
+			"    return [('Decoded', '  \\u00e4\\r\\n\\r\\n\\tvalue  \\n'), ('Empty', '')]\n");
+		REQUIRE(adaptation);
+		auto views = adaptation->getClearText(patch);
+		REQUIRE(views.size() == 2);
+		CHECK(views[0].second == "  \xc3\xa4\r\n\r\n\tvalue  \n");
+		CHECK(views[1].second.empty());
+		CHECK(patch.at(0) == 0xf0);
+	}
+	for (auto code : {
+		"def getClearText(message): raise ValueError('broken view')\n",
+		"def getClearText(message): return [('A', 42)]\n",
+		"def getClearText(message): return [('A', 'x'), ('A', 'y')]\n",
+		"def getClearText(message): return [('', 'x')]\n",
+		"def getClearText(message): return None\n"}) {
+		auto adaptation = run(code);
+		REQUIRE(adaptation);
+		CHECK(adaptation->getClearText(patch).empty());
+		CHECK(adaptation->getName() == "Text fixture");
+		CHECK(adaptation->getClearText(patch).empty());
+	}
+}
+
+TEST_CASE("comparison and sidebar retain custom whitespace through resize and view switching") {
+	juce::ScopedJuceInitialiser_GUI gui;
+	auto synth = std::make_shared<TextSynth>();
+	auto left = test_helpers::makePatchHolder(synth, "Left", {1});
+	auto right = test_helpers::makePatchHolder(synth, "Right", {2});
+	PatchDiff comparison(synth.get(), left, right);
+	auto selectors = children<juce::ComboBox>(comparison);
+	REQUIRE(selectors.size() == 1);
+	selectors[0]->setSelectedId(3, juce::sendNotificationSync);
+	auto editors = children<juce::CodeEditorComponent>(comparison);
+	REQUIRE(editors.size() == 2);
+	CHECK(editors[0]->getDocument().getAllContent() == "  Head\r\n\r\n\tValue: 1  \n");
+	CHECK(editors[1]->getDocument().getAllContent() == "  Head\r\n\r\n\tValue: 2  \n");
+	comparison.setSize(200, 300);
+	CHECK(editors[0]->getDocument().getAllContent() == "  Head\r\n\r\n\tValue: 1  \n");
+	selectors[0]->setSelectedId(1, juce::sendNotificationSync);
+	selectors[0]->setSelectedId(3, juce::sendNotificationSync);
+	CHECK(editors[1]->getDocument().getAllContent() == "  Head\r\n\r\n\tValue: 2  \n");
+
+	PatchTextBox sidebar({}, false);
+	sidebar.fillTextBox(std::make_shared<midikraft::PatchHolder>(left));
+	auto sidebarSelectors = children<juce::ComboBox>(sidebar);
+	REQUIRE(sidebarSelectors.size() == 1);
+	sidebarSelectors[0]->setSelectedId(3, juce::sendNotificationSync);
+	auto sidebarEditors = children<juce::CodeEditorComponent>(sidebar);
+	REQUIRE(sidebarEditors.size() == 1);
+	CHECK(sidebarEditors[0]->getDocument().getAllContent() == "  Head\r\n\r\n\tValue: 1  \n");
+	sidebar.setSize(120, 400);
+	CHECK(sidebarEditors[0]->getDocument().getAllContent() == "  Head\r\n\r\n\tValue: 1  \n");
+	sidebar.fillTextBox(std::make_shared<midikraft::PatchHolder>(right));
+	CHECK(sidebarSelectors[0]->getSelectedId() == 3);
+	CHECK(sidebarEditors[0]->getDocument().getAllContent() == "  Head\r\n\r\n\tValue: 2  \n");
+	auto empty = test_helpers::makePatchHolder(synth, "Empty", {});
+	sidebar.fillTextBox(std::make_shared<midikraft::PatchHolder>(empty));
+	CHECK(sidebarSelectors[0]->getSelectedId() == 1);
+	sidebar.fillTextBox(nullptr);
+	CHECK(sidebarEditors[0]->getDocument().getAllContent() == "No patch active");
+}

--- a/tests/patch_text_test.cpp
+++ b/tests/patch_text_test.cpp
@@ -6,13 +6,19 @@
 #include "The-Orm/PatchDiff.h"
 #include "The-Orm/PatchTextBox.h"
 #include "GenericAdaptation.h"
+#include "Settings.h"
 #include "test_helpers.h"
 
 // Keep JUCE alive for the whole test run, including doctest reporters and
 // queued adaptation error messages, rather than shutting it down in a test case.
 int main(int argc, char** argv) {
 	juce::ScopedJuceInitialiser_GUI gui;
-	return doctest::Context(argc, argv).run();
+	Settings::setSettingsID("KnobKraftPatchTextTests");
+	const auto result = doctest::Context(argc, argv).run();
+	// PropertiesFile owns a Timer, so destroy settings before JUCE's timer
+	// infrastructure shuts down, just as the application does.
+	Settings::shutdown();
+	return result;
 }
 
 namespace {

--- a/tests/patch_text_test.cpp
+++ b/tests/patch_text_test.cpp
@@ -1,4 +1,4 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#define DOCTEST_CONFIG_IMPLEMENT
 #include "doctest/doctest.h"
 
 #include "The-Orm/TextDiffRanges.h"
@@ -7,6 +7,13 @@
 #include "The-Orm/PatchTextBox.h"
 #include "GenericAdaptation.h"
 #include "test_helpers.h"
+
+// Keep JUCE alive for the whole test run, including doctest reporters and
+// queued adaptation error messages, rather than shutting it down in a test case.
+int main(int argc, char** argv) {
+	juce::ScopedJuceInitialiser_GUI gui;
+	return doctest::Context(argc, argv).run();
+}
 
 namespace {
 
@@ -129,7 +136,6 @@ TEST_CASE("Python patch text callback is optional and failures do not poison lat
 }
 
 TEST_CASE("comparison and sidebar retain custom whitespace through resize and view switching") {
-	juce::ScopedJuceInitialiser_GUI gui;
 	auto synth = std::make_shared<TextSynth>();
 	auto left = test_helpers::makePatchHolder(synth, "Left", {1});
 	auto right = test_helpers::makePatchHolder(synth, "Right", {2});

--- a/tests/test_hdiutil_repeat.py
+++ b/tests/test_hdiutil_repeat.py
@@ -1,0 +1,76 @@
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'The-Orm' / 'hdiutil_repeat.sh'
+BASH = (str(Path(os.environ.get('ProgramFiles', 'C:/Program Files')) / 'Git/bin/bash.exe')
+        if os.name == 'nt' else shutil.which('bash'))
+pytestmark = pytest.mark.skipif(not BASH or not Path(BASH).is_file(), reason='bash is required')
+
+
+def run_hdiutil(tmp_path, command, failures, force_failures=0):
+    stub = tmp_path / 'hdiutil'
+    stub.write_text('''#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$CALL_LOG"
+if [ "$1" = info ]; then exit 0; fi
+if [[ " $* " == *" -force "* ]]; then
+  count_file="$FORCE_COUNT"
+  failures="$FORCE_FAILURES"
+else
+  count_file="$NORMAL_COUNT"
+  failures="$NORMAL_FAILURES"
+fi
+count=0
+if [ -f "$count_file" ]; then read -r count < "$count_file"; fi
+count=$((count+1))
+printf '%s\\n' "$count" > "$count_file"
+[ "$count" -gt "$failures" ]
+''', encoding='utf-8', newline='\n')
+    stub.chmod(0o755)
+    sleep = tmp_path / 'sleep'
+    sleep.write_text('#!/usr/bin/env bash\nexit 0\n', encoding='utf-8', newline='\n')
+    sleep.chmod(0o755)
+    env = os.environ.copy()
+    env.update(CALL_LOG=str(tmp_path / 'calls'), NORMAL_COUNT=str(tmp_path / 'normal'),
+               FORCE_COUNT=str(tmp_path / 'force'), NORMAL_FAILURES=str(failures),
+               FORCE_FAILURES=str(force_failures))
+    wrapper = '''stub_dir="$1"
+case "$stub_dir" in [A-Za-z]:*) stub_dir="$(cygpath -u "$stub_dir")";; esac
+export PATH="$stub_dir:$PATH"
+shift
+exec bash "$@"
+'''
+    result = subprocess.run([BASH, '-c', wrapper, '--', str(tmp_path), str(SCRIPT),
+                             command, '/Volumes/Test image'], env=env, capture_output=True,
+                            text=True, timeout=20)
+    return result, (tmp_path / 'calls').read_text().splitlines()
+
+
+def test_detach_recovers_from_transient_forced_failure(tmp_path):
+    result, calls = run_hdiutil(tmp_path, 'detach', 10, 2)
+    assert result.returncode == 0, result.stderr
+    assert calls == ['detach /Volumes/Test image'] * 10 + ['detach /Volumes/Test image -force'] * 3
+
+
+def test_successful_normal_detach_never_forces(tmp_path):
+    result, calls = run_hdiutil(tmp_path, 'detach', 2)
+    assert result.returncode == 0, result.stderr
+    assert calls == ['detach /Volumes/Test image'] * 3
+
+
+def test_permanent_detach_failure_remains_a_failure(tmp_path):
+    result, calls = run_hdiutil(tmp_path, 'detach', 10, 10)
+    assert result.returncode == 1
+    assert len(calls) == 21
+    assert calls[-1] == 'info'
+    assert 'Failed to detach temporary image' in result.stderr
+
+
+def test_create_retries_without_forced_detach(tmp_path):
+    result, calls = run_hdiutil(tmp_path, 'create', 2)
+    assert result.returncode == 0, result.stderr
+    assert calls == ['create /Volumes/Test image'] * 3


### PR DESCRIPTION
Patch comparison currently exposes raw bytes or built-in C++ parameter values, so adaptation authors cannot inspect decoded payloads in the UI. Add an optional `getClearText(message)` callback returning named text views, selectable in both the side-by-side comparison and current-patch sidebar.

The supplied text is displayed verbatim: line endings, blank lines, tabs, spaces, and trailing newlines survive resizing and view switching. Comparison matches views by name, and missing, invalid, or failing callbacks fall back to built-in views. A Korg MS2000 implementation demonstrates an unescaped payload dump with payload-relative offsets.

Replace dtl with JUCE `TextDiff`, translating edit positions into the original documents' character coordinates. Compare corresponding rows when row counts match to retain localized highlighting in long dumps; use whole-document diffs when row counts differ. The comparison and sidebar share parameter formatting. Remove the unused `third_party/dtl` submodule, its registration, and the application include path.

Merged `master` at `d54ea9fc`, retaining both the patch-text capability and the newer patch-event hooks. MidiKraft is pinned to master's merged `5d6baff28cb3391b7ae30d7fcc7d9d4a450933b8`, which includes https://github.com/christofmuc/MidiKraft/pull/14.

Both C++ test executables use `-DBUILD_UNIT_TESTS=ON` (renamed from `BUILD_PATCH_DATABASE_TESTS`). CI, Docker, and repository instructions use the new name; Windows CI runs both executables explicitly. Keep JUCE alive across the patch-text test run and destroy its settings singleton before JUCE teardown, fixing a crash after doctest reported success. Give the tests their own settings identifier.

For the intermittent macOS DMG detach failure, retry forced detach of the same temporary image and preserve a failure result if all attempts fail. Upload CPack logs on failure to expose packaging diagnostics. Four mocked shell tests cover recovery and permanent failure, with a separate Windows CI step so their exit status is preserved.

Validation:
- Fresh Windows `RelWithDebInfo` C++ test build from the merged PR worktree, using pinned submodules and bundled Python 3.12.10: patch text 5 cases / 103 assertions; regression suite 35 cases / 5,644 assertions. Both processes exit 0.
- Korg MS2000 Python tests: 9 passed, 29 skipped.
- DMG helper tests: 4 passed. Workflow YAML parsing and `git diff --check` passed.
- CI passed on final commit `d3f45089`: Windows application build and both C++ test executables, macOS DMG packaging, Ubuntu 22, Ubuntu 24, and docs. GitHub reports the PR clean to merge.

Closes #478.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable patch text views, including raw hexadecimal, parameter values, and adaptation-provided custom views.
  * Patch comparisons now match shared custom views by name, highlight localized differences, and preserve formatting.
  * Added readable patch data views for compatible adaptations, including Korg MS-2000 data.

* **Documentation**
  * Documented how to provide and use additional patch text views.

* **Tests**
  * Added coverage for text comparisons, custom views, formatting preservation, and adaptation callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
