### PR TITLE
Fix secondary MIDI routing and add adaptation patch hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,7 @@ if(BUILD_PATCH_DATABASE_TESTS)
 		tests/bank_send_test.cpp
 		tests/trigon_rename_test.cpp
 		tests/upload_handshake_test.cpp
+		tests/patch_event_test.cpp
 		tests/test_helpers.h
 		The-Orm/UserBankFactory.cpp)
 	target_include_directories(patch_database_migration_test PRIVATE

--- a/The-Orm/CMakeLists.txt
+++ b/The-Orm/CMakeLists.txt
@@ -83,6 +83,7 @@ set(SOURCES
 	PatchSearchComponent.cpp PatchSearchComponent.h
 	PatchTextBox.cpp PatchTextBox.h
 	PatchView.cpp PatchView.h
+	PatchSelectionEvents.h
 	ReceiveManualDumpWindow.cpp ReceiveManualDumpWindow.h
 	RecordingView.cpp RecordingView.h
 	RotaryWithLabel.cpp RotaryWithLabel.h

--- a/The-Orm/KeyboardMacroView.cpp
+++ b/The-Orm/KeyboardMacroView.cpp
@@ -540,31 +540,6 @@ bool KeyboardMacroView::isMacroState(KeyboardMacro const &macro)
 	return allDetected && !extraKeyDetected;
 }
 
-void KeyboardMacroView::handleMidiMessage(const MidiMessage& message, const String& source, bool isOut)
-{
-	if (!isOut) {
-		// Don't relay incoming messages
-		return;
-	}
-
-	juce::MidiDeviceInfo secondaryInfo;
-	{
-		std::scoped_lock lock(secondaryMidiOutMutex_);
-		secondaryInfo = secondaryMidiOut_;
-	}
-
-	if (secondaryInfo.name.isEmpty() || source == secondaryInfo.name) {
-		// No secondary selected or coming from secondary device - avoid loops!
-		return;
-	}
-
-	auto secondaryOutput = midikraft::MidiController::instance()->getMidiOutput(secondaryInfo);
-	if (secondaryOutput->isValid()) {
-		// Forward a copy to the secondary output
-		secondaryOutput->sendMessageNow(message);
-	}
-}
-
 void KeyboardMacroView::refreshSecondaryMidiOutList()
 {
 	if (secondaryMidiOutList_) {
@@ -578,8 +553,5 @@ void KeyboardMacroView::updateSecondaryMidiOutSelection()
 		return;
 	}
 
-	{
-		std::scoped_lock lock(secondaryMidiOutMutex_);
-		secondaryMidiOut_ = secondaryMidiOutList_->selectedDevice();
-	}
+	midikraft::MidiController::instance()->setSecondaryMidiOutput(secondaryMidiOutList_->selectedDevice());
 }

--- a/The-Orm/KeyboardMacroView.h
+++ b/The-Orm/KeyboardMacroView.h
@@ -15,15 +15,12 @@
 #include "MidiChannelPropertyEditor.h"
 #include "ElectraOneRouter.h"
 
-#include <mutex>
-
 class KeyboardMacroView : public Component, private ChangeListener, private Value::Listener {
 public:
 	KeyboardMacroView(std::function<void(KeyboardMacroEvent)> callback);
 	virtual ~KeyboardMacroView() override;
 
 	virtual void resized() override;
-	void handleMidiMessage(const MidiMessage& message, const String& source, bool isOut);
 
 private:
 	class RecordProgress;
@@ -64,6 +61,4 @@ private:
 	TypedNamedValueSet customMasterkeyboardSetup_;
 	std::shared_ptr<RecordProgress> activeRecorder_; // Should have maximum one active macro recorders open
 
-	std::mutex secondaryMidiOutMutex_;
-	juce::MidiDeviceInfo secondaryMidiOut_;
 };

--- a/The-Orm/MainComponent.cpp
+++ b/The-Orm/MainComponent.cpp
@@ -533,9 +533,6 @@ MainComponent::MainComponent(bool makeYourOwnSize) :
 
 	// Install our MidiLogger
 	midikraft::MidiController::instance()->setMidiLogFunction([this](const MidiMessage& message, const String& source, bool isOut) {
-		if (keyboardView_) {
-			keyboardView_->handleMidiMessage(message, source, isOut);
-		}
 		midiLogView_.log().addMessageToList(message, source, isOut);
 		});
 

--- a/The-Orm/PatchSelectionEvents.h
+++ b/The-Orm/PatchSelectionEvents.h
@@ -1,0 +1,40 @@
+/*
+   Copyright (c) 2026 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#pragma once
+
+#include "Capability.h"
+#include "MidiController.h"
+#include "PatchEventCapability.h"
+#include "Synth.h"
+#include "UploadSequence.h"
+
+// Retain the selection's channel and bytes across an asynchronous upload, without
+// keeping the synth (which owns the upload and its completion callback) alive.
+class PatchSelectionEvents {
+public:
+	PatchSelectionEvents(std::shared_ptr<midikraft::Synth> const& synth, MidiChannel channel, std::vector<uint8> data)
+		: synth_(synth), channel_(channel), data_(std::move(data)) {}
+
+	void selected() const { dispatch(false); }
+	void sent(const midikraft::UploadResult& result) const {
+		if (result.successful()) dispatch(true);
+	}
+
+private:
+	void dispatch(bool wasSent) const {
+		if (auto synth = synth_.lock()) {
+			if (auto events = midikraft::Capability::hasCapability<midikraft::PatchEventCapability>(synth)) {
+				auto messages = wasSent ? events->onPatchSent(channel_, data_) : events->onPatchSelected(channel_, data_);
+				if (!messages.empty()) midikraft::MidiController::instance()->sendToSecondaryMidiOut(messages);
+			}
+		}
+	}
+
+	std::weak_ptr<midikraft::Synth> synth_;
+	MidiChannel channel_;
+	std::vector<uint8> data_;
+};

--- a/The-Orm/PatchView.cpp
+++ b/The-Orm/PatchView.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "PatchView.h"
+#include "PatchSelectionEvents.h"
 
 #include "PatchSearchComponent.h"
 #include "SimplePatchGrid.h"
@@ -1094,11 +1095,19 @@ std::vector<MidiMessage> PatchView::buildSelectBankAndProgramMessages(MidiProgra
 }
 
 void PatchView::sendProgramChangeMessagesForPatch(std::shared_ptr<midikraft::MidiLocationCapability> midiLocation,  MidiProgramNumber program, midikraft::PatchHolder &patch) {
+	if (!midikraft::MidiController::instance()->getMidiOutput(midiLocation->midiOutput())->isValid()) {
+		spdlog::error("MIDI output unavailable for {}", patch.smartSynth()->getName());
+		return;
+	}
 	// We can get away with just a bank select and program change, and will try to select the patch directly
 		// Build the MIDI messages required to select bank and program
 	auto selectPatch = buildSelectBankAndProgramMessages(program, patch);
 	if (selectPatch.size() > 0) {
 		patch.smartSynth()->sendBlockOfMessagesToSynth(midiLocation->midiOutput(), selectPatch);
+		if (patch.patch()) {
+			PatchSelectionEvents(patch.smartSynth(), midiLocation->channel(), patch.patch()->data())
+				.sent({ midikraft::UploadResult::Status::SENT_WITHOUT_ACKNOWLEDGEMENT, {}, {} });
+		}
 	}
 	else {
 		if (midikraft::Capability::hasCapability<midikraft::CustomProgramChangeCapability>(patch.smartSynth())) {
@@ -1114,11 +1123,17 @@ void PatchView::sendPatchAsSysex(midikraft::PatchHolder &patch) {
 	// Send out to Synth into edit buffer
 	if (patch.patch()) {
 		spdlog::info("Sending sysex for patch '{}' to {}", patch.name(), patch.synth()->getName());
-		if (midikraft::Capability::hasCapability<midikraft::UploadHandshakeCapability>(patch.synth())) {
-			patch.synth()->sendDataFileToSynthAsync(patch.patch(), nullptr, [synthName = patch.synth()->getName()](const midikraft::UploadResult& result) {
+		auto events = midikraft::Capability::hasCapability<midikraft::PatchEventCapability>(patch.smartSynth());
+		if (events || midikraft::Capability::hasCapability<midikraft::UploadHandshakeCapability>(patch.synth())) {
+			auto location = midikraft::Capability::hasCapability<midikraft::MidiLocationCapability>(patch.smartSynth());
+			auto channel = location ? location->channel() : MidiChannel::invalidChannel();
+			PatchSelectionEvents notifications(patch.smartSynth(), channel, patch.patch()->data());
+			patch.synth()->sendDataFileToSynthAsync(patch.patch(), nullptr, [notifications, synthName = patch.synth()->getName()](const midikraft::UploadResult& result) {
 				if (!result.successful()) {
 					spdlog::error("Upload to {} failed: {}", synthName, result.message);
+					return;
 				}
+				notifications.sent(result);
 			});
 		}
 		else {
@@ -1143,6 +1158,11 @@ void PatchView::selectPatch(midikraft::PatchHolder &patch, bool alsoSendToSynth)
 
 		UIModel::instance()->currentPatch_.changeCurrentPatch(patch);
 		currentLayer_ = 0;
+		if (patch.patch()) {
+			auto location = midikraft::Capability::hasCapability<midikraft::MidiLocationCapability>(patch.smartSynth());
+			auto channel = location ? location->channel() : MidiChannel::invalidChannel();
+			PatchSelectionEvents(patch.smartSynth(), channel, patch.patch()->data()).selected();
+		}
 
 		if (alsoSendToSynth) {
 			auto midiLocation = midikraft::Capability::hasCapability<midikraft::MidiLocationCapability>(patch.smartSynth());

--- a/adaptations/GenericAdaptation.cpp
+++ b/adaptations/GenericAdaptation.cpp
@@ -85,6 +85,8 @@ namespace knobkraft {
 		* kSetupHelp = "setupHelp",
 		* kGetStoredTags = "storedTags",
 		* kIndicateBankDownloadMethod= "bankDownloadMethodOverride",
+		* kOnPatchSelected = "onPatchSelected",
+		* kOnPatchSent = "onPatchSent",
 		* kMessageTimings = "messageTimings",
 		* kExpectsUploadReply = "expectsUploadReply",
 		* kIsPartOfUploadReply = "isPartOfUploadReply";
@@ -129,6 +131,8 @@ namespace knobkraft {
 		kSetupHelp,
 		kGetStoredTags,
 		kMessageTimings,
+		kOnPatchSelected,
+		kOnPatchSent,
 		kExpectsUploadReply,
 		kIsPartOfUploadReply
 	};
@@ -141,7 +145,7 @@ namespace knobkraft {
 
 	const char* kUserAdaptationsFolderSettingsKey = "user_adaptations_folder";
 	constexpr auto kAdaptationApiVersionAttribute = "_knobkraft_adaptation_api_version";
-	constexpr int kAdaptationApiVersion = 2;
+	constexpr int kAdaptationApiVersion = 3;
 
 	std::unique_ptr<py::scoped_interpreter> sGenericAdaptationPythonEmbeddedGuard;
 	std::unique_ptr<py::gil_scoped_release> sGenericAdaptationDontLockGIL;
@@ -1144,6 +1148,70 @@ namespace knobkraft {
 			return true;
 		}
 		return false;
+	}
+
+	std::vector<MidiMessage> GenericAdaptation::onPatchSelected(MidiChannel channel, std::vector<uint8> const& patchData) const
+	{
+		return patchEventMessages(kOnPatchSelected, channel, patchData);
+	}
+
+	std::vector<MidiMessage> GenericAdaptation::onPatchSent(MidiChannel channel, std::vector<uint8> const& patchData) const
+	{
+		return patchEventMessages(kOnPatchSent, channel, patchData);
+	}
+
+	std::vector<MidiMessage> GenericAdaptation::patchEventMessages(const char* event, MidiChannel channel, std::vector<uint8> const& patchData) const
+	{
+		py::gil_scoped_acquire acquire;
+		if (!pythonModuleHasFunction(event)) return {};
+		try {
+			int channelNumber = channel.isValid() ? channel.toZeroBasedInt() : -1;
+			std::vector<int> data(patchData.begin(), patchData.end());
+			auto result = callMethod(event, channelNumber, data);
+			if (result.is_none()) return {};
+			auto bytes = result.cast<std::vector<int>>();
+			std::vector<uint8> midi;
+			for (int byte : bytes) {
+				if (byte < 0 || byte > 255) throw std::invalid_argument("Hook MIDI bytes must be in the range 0..255");
+				midi.push_back(static_cast<uint8>(byte));
+			}
+
+			// Validate the entire result before sending anything. Require complete messages
+			// with explicit status bytes; a truncated hook result must not send half a command.
+			std::vector<MidiMessage> messages;
+			for (size_t start = 0; start < midi.size();) {
+				auto status = midi[start];
+				if (status < 0x80 || status == 0xf4 || status == 0xf5 || status == 0xf7 || status == 0xf9 || status == 0xfd) {
+					throw std::invalid_argument("Hook MIDI must contain complete messages with explicit status bytes");
+				}
+				size_t end;
+				if (status == 0xf0) {
+					end = start + 1;
+					while (end < midi.size() && midi[end] < 0x80) ++end;
+					if (end == midi.size() || midi[end] != 0xf7 || end == start + 1) {
+						throw std::invalid_argument("Hook SysEx must contain a payload and end with F7");
+					}
+					++end;
+				}
+				else {
+					end = start + static_cast<size_t>(MidiMessage::getMessageLengthFromFirstByte(status));
+					if (end > midi.size()) throw std::invalid_argument("Hook MIDI message is truncated");
+					for (size_t i = start + 1; i < end; ++i) {
+						if (midi[i] >= 0x80) throw std::invalid_argument("Hook MIDI data bytes must be in the range 0..127");
+					}
+				}
+				messages.emplace_back(midi.data() + start, static_cast<int>(end - start), 0.0);
+				start = end;
+			}
+			return messages;
+		}
+		catch (py::error_already_set& ex) {
+			logAdaptationError(event, ex);
+		}
+		catch (std::exception& ex) {
+			logAdaptationError(event, ex);
+		}
+		return {};
 	}
 
 	void GenericAdaptation::logAdaptationError(const char* methodName, std::exception& ex) const

--- a/adaptations/GenericAdaptation.h
+++ b/adaptations/GenericAdaptation.h
@@ -16,6 +16,7 @@
 #include "BankDumpCapability.h"
 #include "LegacyLoaderCapability.h"
 #include "CustomProgramChangeCapability.h"
+#include "PatchEventCapability.h"
 #include "UploadHandshakeCapability.h"
 
 #ifdef _MSC_VER
@@ -77,6 +78,7 @@ namespace knobkraft {
 		public midikraft::RuntimeCapability<midikraft::CustomProgramChangeCapability>,
 		public midikraft::RuntimeCapability<midikraft::UploadHandshakeCapability>,
 		public midikraft::BankDownloadMethodIndicationCapability,
+		public midikraft::PatchEventCapability,
 		public std::enable_shared_from_this<GenericAdaptation>
 	{
 	public:
@@ -109,6 +111,8 @@ namespace knobkraft {
 		virtual void sendBlockOfMessagesToSynth(juce::MidiDeviceInfo const &midiOutput, std::vector<MidiMessage> const& buffer) override;
 		virtual std::string friendlyProgramName(MidiProgramNumber programNo) const override;  //TODO this looks like a capability
 		virtual std::string setupHelpText() const override;
+		std::vector<MidiMessage> onPatchSelected(MidiChannel channel, std::vector<uint8> const& patchData) const override;
+		std::vector<MidiMessage> onPatchSent(MidiChannel channel, std::vector<uint8> const& patchData) const override;
 
 		// Internal workings of the Generic Adaptation module
 		bool pythonModuleHasFunction(std::string const &functionName) const;
@@ -172,6 +176,7 @@ namespace knobkraft {
 		void insertFingerprint(Synth::PatchData const& patchData, std::string const& inName) const;
 
 	private:
+		std::vector<MidiMessage> patchEventMessages(const char* event, MidiChannel channel, std::vector<uint8> const& patchData) const;
 		friend class GenericEditBufferCapability;
 		std::shared_ptr<GenericEditBufferCapability> editBufferCapabilityImpl_;
 

--- a/adaptations/conftest.py
+++ b/adaptations/conftest.py
@@ -11,7 +11,7 @@ import sys
 
 # Pytest imports adaptations without the C++ application, so advertise the API
 # level provided by the current GenericAdaptation host bridge.
-setattr(sys, "_knobkraft_adaptation_api_version", 2)
+setattr(sys, "_knobkraft_adaptation_api_version", 3)
 
 
 def load_adaptation(adaptation_file):

--- a/docs/programming-guide.md
+++ b/docs/programming-guide.md
@@ -688,6 +688,34 @@ The funky last return line is a Python idiom to convert a list of bytes (or inte
 
 Some capabilities are not required to be implemented, but enhance the user experience.
 
+## Patch selection and send notifications
+
+Host API version 3 adds two optional hooks:
+
+```python
+def onPatchSelected(channel, message):
+    return []
+
+def onPatchSent(channel, message):
+    return [0xC0, 7]  # Example: program 8 on channel 1 of the secondary device.
+```
+
+Select **Secondary MIDI OUT** in the Macros tab to choose the destination. Both hooks return a flat list of MIDI bytes for that output only. Include a status byte for every message and `F0`/`F7` around each SysEx message. Multiple complete messages can be concatenated. KnobKraft preserves their order and channels. Returning `[]`, `None`, or omitting the hook produces no additional MIDI. A malformed result or a Python exception is logged and produces no hook MIDI; normal patch handling continues.
+
+`onPatchSelected` runs whenever a nonempty patch is selected in the library, including reselecting the same patch and selecting with sending disabled or the synth disconnected. It runs after updating the current library patch and before any send initiated by that selection.
+
+`onPatchSent` runs after a library selection successfully sends its edit/program dump or bank-select/program-change sequence. For synths with upload handshakes it waits for successful completion. Without a handshake, it means MIDI was submitted to the output; it does not confirm that the hardware accepted it. Failed, cancelled, busy, and skipped sends do not call this hook. An asynchronous completion refers to the patch that was sent, even if the user has since selected another patch.
+
+`channel` is the synth's zero-based MIDI channel (0–15), or `-1` when unknown at selection time. `message` is a copy of the original library patch's bytes, not the converted wire messages. Modifying this Python list does not change the patch or what KnobKraft sends. Neither hook runs for export, fingerprinting, conversion alone, bank uploads, or incoming master-keyboard messages.
+
+For a controller such as the Faderfox EC4, implement `onPatchSent` in the personalized adaptation and return the controller's setup-select SysEx instead of the example program change above. Use the controller's documented or captured message, including `F0` and `F7`. Faderfox describes remote setup/group selection in its [EC4 manual, page 7](https://www.faderfox.de/PDF/EC4%20Manual%20V03.pdf), and offers the advanced programming documentation on request through the [EC4 product page](https://www.faderfox.de/ec4.html). The synth's normal patch send completes first, then the controller switches setup. Use `onPatchSelected` instead if the controller should follow browsing even when no patch is sent. Implementing both can send the same controller command twice for one selection.
+
+The hooks run even when the secondary output is disabled or unavailable, but their output is discarded in that case. Ordinary outgoing MIDI is also mirrored to the secondary output, independently of the log filter. Hook output is sent once and does not recursively trigger mirroring or either hook. If the secondary output is configured to be the synth's own port, the additional MIDI will of course reach that physical port.
+
+These are notifications, not patch transformations or request/reply operations. Keep hooks short: they run synchronously on the host's event path and must not wait for MIDI replies. KnobKraft owns MIDI routing and send sequencing; there is no Python `sendToSynth()` or `sendToSecondaryMidiOut()` callback. Preserving sequencer data from a live edit buffer would require a separate host-managed read/transform/send operation.
+
+Older hosts ignore these hooks. If your adaptation requires them, use `knobkraft.require_host_api_version(3, "My adaptation")`; otherwise leave the hooks optional so its existing synth functions still work on older hosts.
+
 ## Throttling communication
 
 Some older devices don't like it if multiple messages are sent to them too quickly, their small processors need a while to finish with message received and they might just ignore another message if it comes up too quickly. Actually some older devices are really good and fast despite running on some 2 MHz micro-processor like the Zilog Z80, but many also like it if there is a delay between messages.

--- a/docs/programming-guide.md
+++ b/docs/programming-guide.md
@@ -692,13 +692,11 @@ Some capabilities are not required to be implemented, but enhance the user exper
 
 Host API version 3 adds two optional hooks:
 
-```python
-def onPatchSelected(channel, message):
-    return []
+    def onPatchSelected(channel, message):
+        return []
 
-def onPatchSent(channel, message):
-    return [0xC0, 7]  # Example: program 8 on channel 1 of the secondary device.
-```
+    def onPatchSent(channel, message):
+        return [0xC0, 7]  # Example: program 8 on channel 1 of the secondary device.
 
 Select **Secondary MIDI OUT** in the Macros tab to choose the destination. Both hooks return a flat list of MIDI bytes for that output only. Include a status byte for every message and `F0`/`F7` around each SysEx message. Multiple complete messages can be concatenated. KnobKraft preserves their order and channels. Returning `[]`, `None`, or omitting the hook produces no additional MIDI. A malformed result or a Python exception is logged and produces no hook MIDI; normal patch handling continues.
 

--- a/tests/bank_dump_capability_test.cpp
+++ b/tests/bank_dump_capability_test.cpp
@@ -142,7 +142,7 @@ def extractPatchesFromAllBankMessages(messages):
 )");
 
 	REQUIRE(adaptation);
-	CHECK(pythonSystem.attr("_knobkraft_adaptation_api_version").cast<int>() == 2);
+	CHECK(pythonSystem.attr("_knobkraft_adaptation_api_version").cast<int>() >= 2);
 	std::shared_ptr<midikraft::BankSendCapability> sendCapability;
 	REQUIRE(adaptation->hasCapability(sendCapability));
 	auto bankMessages = sendCapability->createBankMessages({});

--- a/tests/patch_event_test.cpp
+++ b/tests/patch_event_test.cpp
@@ -1,0 +1,127 @@
+#include "doctest/doctest.h"
+
+#include "GenericAdaptation.h"
+#include "The-Orm/PatchSelectionEvents.h"
+
+#include <pybind11/embed.h>
+#include <algorithm>
+
+namespace py = pybind11;
+
+TEST_CASE("patch hooks are optional and receive a copy of the patch with its channel") {
+	py::scoped_interpreter python;
+	auto synth = knobkraft::GenericAdaptation::fromBinaryCode("patch_hooks", R"(
+def name(): return "Patch hook test"
+def onPatchSelected(channel, message):
+    assert channel == -1
+    assert message == [0xf0, 0x7d, 1, 0xf7]
+    message[2] = 99
+    return [0xc0, 7, 0xf0, 0x7d, 2, 0xf7]
+def onPatchSent(channel, message):
+    assert channel == 2
+    assert message == [0xf0, 0x7d, 1, 0xf7]
+    return [0xb1, 0, 2, 0xc1, 42]
+)");
+	REQUIRE(synth);
+	const std::vector<uint8> patch{ 0xf0, 0x7d, 1, 0xf7 };
+	auto selected = synth->onPatchSelected(MidiChannel::invalidChannel(), patch);
+	REQUIRE(selected.size() == 2);
+	CHECK(selected[0].getProgramChangeNumber() == 7);
+	CHECK(selected[1].isSysEx());
+	CHECK(patch[2] == 1);
+	auto sent = synth->onPatchSent(MidiChannel::fromZeroBase(2), patch);
+	REQUIRE(sent.size() == 2);
+	CHECK(sent[0].isController());
+	CHECK(sent[1].getChannel() == 2); // Hook output channel is not rewritten to the synth channel.
+	CHECK(sent[1].getProgramChangeNumber() == 42);
+
+	auto legacy = knobkraft::GenericAdaptation::fromBinaryCode("legacy_without_patch_hooks", "def name(): return 'Legacy'");
+	REQUIRE(legacy);
+	CHECK(legacy->onPatchSelected(MidiChannel::fromZeroBase(0), patch).empty());
+	CHECK(legacy->onPatchSent(MidiChannel::fromZeroBase(0), patch).empty());
+}
+
+TEST_CASE("invalid hook results are rejected as a whole and Python errors do not poison subsequent hooks") {
+	py::scoped_interpreter python;
+	const std::vector<std::string> invalidResults{
+		"[0xc0, 1, 0xf0, 0x7d]", // Valid first message followed by unfinished SysEx.
+		"[0xc0]", "[0x90, 60]", "[0xc0, 128]", "[0xf0, 0xf7]",
+		"[0xf0, 0x7d, 0x90, 0xf7]", "[0xf7]", "[0xf4]", "[7, 8]",
+		"[256]", "[-1]", "'not MIDI'", "{'synth': [0xc0, 1]}"
+	};
+	for (const auto& result : invalidResults) {
+		INFO(result);
+		auto synth = knobkraft::GenericAdaptation::fromBinaryCode("invalid_patch_hook",
+			"def name(): return 'Invalid hook'\ndef onPatchSelected(channel, message): return " + result
+			+ "\ndef onPatchSent(channel, message): return [0xc0, 9]\n");
+		REQUIRE(synth);
+		CHECK(synth->onPatchSelected(MidiChannel::fromZeroBase(0), {}).empty());
+		CHECK(synth->onPatchSent(MidiChannel::fromZeroBase(0), {}).size() == 1);
+	}
+	auto throwing = knobkraft::GenericAdaptation::fromBinaryCode("throwing_patch_hook", R"(
+def name(): return "Throwing hook"
+def onPatchSelected(channel, message): raise ValueError("broken hook")
+def onPatchSent(channel, message): return [0xc0, 9]
+)");
+	REQUIRE(throwing);
+	CHECK(throwing->onPatchSelected(MidiChannel::fromZeroBase(0), {}).empty());
+	CHECK(throwing->onPatchSent(MidiChannel::fromZeroBase(0), {}).size() == 1);
+	CHECK(PyErr_Occurred() == nullptr);
+}
+
+TEST_CASE("empty hook results are no-ops and hooks are discoverable in host API 3") {
+	py::scoped_interpreter python;
+	auto synth = knobkraft::GenericAdaptation::fromBinaryCode("empty_patch_hooks", R"(
+import sys
+assert sys._knobkraft_adaptation_api_version >= 3
+def name(): return "Empty hooks"
+def onPatchSelected(channel, message): pass
+def onPatchSent(channel, message): return []
+)");
+	REQUIRE(synth);
+	CHECK(synth->onPatchSelected(MidiChannel::fromZeroBase(0), {}).empty());
+	CHECK(synth->onPatchSent(MidiChannel::fromZeroBase(0), {}).empty());
+	for (const auto* hook : { "onPatchSelected", "onPatchSent" }) {
+		CHECK(std::find_if(knobkraft::kAdaptationPythonFunctionNames.begin(), knobkraft::kAdaptationPythonFunctionNames.end(),
+			[hook](const char* name) { return std::string(name) == hook; }) != knobkraft::kAdaptationPythonFunctionNames.end());
+	}
+}
+
+TEST_CASE("selection notifications retain their patch snapshot and sent notifications require success") {
+	py::scoped_interpreter python;
+	auto synth = knobkraft::GenericAdaptation::fromBinaryCode("patch_event_dispatch", R"(
+import sys
+sys._patch_hook_calls = []
+def name(): return "Dispatch test"
+def onPatchSelected(channel, message):
+    assert channel == 4
+    assert message == [0xf0, 0x7d, 1, 0xf7]
+    sys._patch_hook_calls.append("selected")
+def onPatchSent(channel, message):
+    assert channel == 4
+    assert message == [0xf0, 0x7d, 1, 0xf7]
+    sys._patch_hook_calls.append("sent")
+)");
+	REQUIRE(synth);
+	auto calls = py::module_::import("sys").attr("_patch_hook_calls").cast<py::list>();
+	std::vector<uint8> patch{ 0xf0, 0x7d, 1, 0xf7 };
+	PatchSelectionEvents notifications(synth, MidiChannel::fromZeroBase(4), patch);
+	patch[2] = 99;
+	CHECK(calls.empty());
+	notifications.selected(); // Browsing without sending still calls onPatchSelected.
+	REQUIRE(calls.size() == 1);
+	CHECK(calls[0].cast<std::string>() == "selected");
+	using Status = midikraft::UploadResult::Status;
+	for (auto status : { Status::DEVICE_ERROR, Status::TIMEOUT, Status::CANCELLED, Status::TRANSPORT_ERROR, Status::ADAPTATION_ERROR, Status::BUSY }) {
+		notifications.sent({ status, {}, {} });
+		CHECK(calls.size() == 1);
+	}
+	notifications.sent({ Status::ACKNOWLEDGED, {}, {} });
+	REQUIRE(calls.size() == 2);
+	CHECK(calls[1].cast<std::string>() == "sent");
+	notifications.sent({ Status::SENT_WITHOUT_ACKNOWLEDGEMENT, {}, {} });
+	CHECK(calls.size() == 3);
+	synth.reset();
+	notifications.sent({ Status::ACKNOWLEDGED, {}, {} });
+	CHECK(calls.size() == 3); // Pending notification does not retain a destroyed synth.
+}


### PR DESCRIPTION
Fixes #468.

Secondary MIDI output now forwards program changes, bank select, notes, SysEx, and realtime messages independently of the MIDI log filter. Routing moves out of the UI log callback into MidiKraft's output layer, fixing the default SysEx-only logging setting suppressing other messages.

Host API version 3 adds two optional adaptation hooks: `onPatchSelected(channel, message)` runs on library selection, including browsing with sending disabled; `onPatchSent(channel, message)` runs after that selection's patch dump or bank-select/program-change send succeeds. Handshake uploads wait for successful completion, and failed, cancelled, busy, or skipped sends do not trigger the sent hook. Asynchronous completions retain the original patch snapshot.

Both hooks receive the synth channel and a copy of the library patch, and return a flat list of complete MIDI messages for the configured secondary output. Existing adaptations can omit them. Empty results are no-ops; malformed output and Python exceptions produce no hook MIDI and do not interrupt normal patch handling. C++ controls routing and completion; patch transformations, synth-directed hook messages, and Python send callbacks are outside this change.

The programming guide documents the contract and shows how a personalized adaptation can return its EC4 setup-select SysEx from `onPatchSent`, or use `onPatchSelected` to follow browsing.

Includes merged dependency https://github.com/christofmuc/MidiKraft/pull/15, pinned at merge commit `5d6baff28cb3391b7ae30d7fcc7d9d4a450933b8`. Its source tree is identical to the tested dependency revision. The dependency also fixes a timeout-sentinel debug crash exposed by the routing tests.

Validation:

- Full Linux Debug application build succeeds with GCC 13.3 and embedded Python 3.12.3.
- MidiKraft base tests: 8 cases, 40 assertions passed.
- Application C++ tests: all 35 cases and 5,644 assertions pass when each source-file group runs in a separate process, including 4 new hook cases and 74 assertions.
- Focused Python 3.12 compatibility tests: `test_Roland_MKS50.py`, 38 passed.
- `git diff --check` passes in both repositories.

The combined C++ runner crashes in the existing Trigon rename test when Python is finalized and restarted after the bank-dump tests. This reproduces with only those two existing source files, excluding every new hook test; Python fault diagnostics point to the OpenSSL constructor in `hashlib`. Both groups pass separately. No application startup or physical MIDI/EC4 timing test was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional adaptation hooks for patch selection and successful patch transmission.
  * Patch events can send custom MIDI messages to the secondary MIDI output.
  * Patch information is preserved during asynchronous uploads.

* **Bug Fixes**
  * Invalid or failed hook responses are safely ignored while normal patch handling continues.
  * MIDI logging no longer forwards messages to keyboard macro handling.

* **Documentation**
  * Documented patch event hooks, API requirements, behavior, and usage examples.

* **Tests**
  * Added coverage for notifications, validation, failure handling, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->